### PR TITLE
Update node runtime timeout

### DIFF
--- a/src/_shims/node-runtime.ts
+++ b/src/_shims/node-runtime.ts
@@ -38,8 +38,8 @@ async function fileFromPath(path: string, ...args: any[]): Promise<File> {
   return await _fileFromPath(path, ...args);
 }
 
-const defaultHttpAgent: Agent = new KeepAliveAgent({ keepAlive: true, timeout: 5 * 60 * 1000 });
-const defaultHttpsAgent: Agent = new KeepAliveAgent.HttpsAgent({ keepAlive: true, timeout: 5 * 60 * 1000 });
+const defaultHttpAgent: Agent = new KeepAliveAgent({ keepAlive: true, timeout: 10 * 60 * 1000 });
+const defaultHttpsAgent: Agent = new KeepAliveAgent.HttpsAgent({ keepAlive: true, timeout: 10 * 60 * 1000 });
 
 async function getMultipartRequestOptions<T = Record<string, unknown>>(
   form: fd.FormData,

--- a/src/resources/devboxes/devboxes.ts
+++ b/src/resources/devboxes/devboxes.ts
@@ -195,10 +195,8 @@ export class Devboxes extends APIResource {
    * Updates a devbox by doing a complete update the existing name,metadata fields.
    * It does not patch partial values.
    */
-  update(id: string, body?: DevboxUpdateParams, options?: Core.RequestOptions): Core.APIPromise<DevboxView>
-;
-  update(id: string, options?: Core.RequestOptions): Core.APIPromise<DevboxView>
-;
+  update(id: string, body?: DevboxUpdateParams, options?: Core.RequestOptions): Core.APIPromise<DevboxView>;
+  update(id: string, options?: Core.RequestOptions): Core.APIPromise<DevboxView>;
   update(
     id: string,
     body: DevboxUpdateParams | Core.RequestOptions = {},


### PR DESCRIPTION
From readme

>`@runloop/api-client/_shims/auto/runtime` exports web runtime shims.
If the `node` export condition is set, the export map replaces it with `@runloop/api-client/_shims/auto/runtime-node`.

Detail was probably using a node runtime, which had a timeout of 5 min 🤦 