### PR TITLE
fix: revert workflow actions to runloopai forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           github.repository == 'stainless-sdks/runloop-node' &&
           !startsWith(github.ref, 'refs/heads/stl/')
         id: github-oidc
-        uses: actions/github-script@v8
+        uses: runloopai/github-script@main
         with:
           script: core.setOutput('github_token', await core.getIDToken());
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/runloop-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Set up Node
         uses: runloopai/setup-node@main
@@ -46,7 +46,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Set up Node
         uses: runloopai/setup-node@main
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ github.repository == 'stainless-sdks/runloop-node' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Set up Node
         uses: runloopai/setup-node@main

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -39,7 +39,7 @@ jobs:
 
       - run: mkdir -p ./docs
       - name: Download the existing documents artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: runloopai/download-artifact@main
         with:
           name: documentation
       - run: tar -xf documentation.tar
@@ -81,7 +81,7 @@ jobs:
 
       - run: mkdir -p ./docs
       - name: Download the new documents artifact
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: runloopai/download-artifact@main
         with:
           name: newdocumentation
       - run: tar -xf newdocumentation.tar

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write # Required for OIDC
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Set up Node
         uses: runloopai/setup-node@main

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'runloopai/api-client-ts' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please') || github.head_ref == 'next')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: runloopai/checkout@main
 
       - name: Check release environment
         run: |


### PR DESCRIPTION
## Summary
- Reverts `actions/checkout@v6` → `runloopai/checkout@main` in `ci.yml`, `publish-npm.yml`, and `release-doctor.yml`
- Reverts `actions/github-script@v8` → `runloopai/github-script@main` in `ci.yml`
- Reverts `actions/download-artifact` → `runloopai/download-artifact@main` in `publish-docs.yml`
- These were accidentally changed in commit fcc267a

## Test plan
- [ ] CI workflows run successfully with runloopai action forks

🤖 Generated with [Claude Code](https://claude.com/claude-code)