### PR TITLE
feat(devbox): add provisioning_tier (flex) to LaunchParameters (alpha)

### DIFF
--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -285,6 +285,12 @@ export interface LaunchParameters {
   network_policy_id?: string | null;
 
   /**
+   * (Optional) standard is default and flex is lazily provisioned and may be
+   * pre-empted.
+   */
+  provisioning_tier?: 'standard' | 'flex' | null;
+
+  /**
    * A list of ContainerizedService names to be started when a Devbox is created. A
    * valid ContainerizedService must be specified in Blueprint to be started.
    */

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -285,8 +285,8 @@ export interface LaunchParameters {
   network_policy_id?: string | null;
 
   /**
-   * (Optional) standard is default and flex is lazily provisioned and may be
-   * pre-empted.
+   * (Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
+   * This is an alpha feature and its behavior may change without notice.
    */
   provisioning_tier?: 'standard' | 'flex' | null;
 

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -285,8 +285,8 @@ export interface LaunchParameters {
   network_policy_id?: string | null;
 
   /**
-   * (Alpha) standard is default and flex is lazily provisioned and may be pre-empted.
-   * This is an alpha feature and its behavior may change without notice.
+   * (Optional, Alpha) standard is default and flex is lazily provisioned and may be
+   * pre-empted. This is an alpha feature and its behavior may change without notice.
    */
   provisioning_tier?: 'standard' | 'flex' | null;
 


### PR DESCRIPTION
### Description

Adds the optional `provisioning_tier` field (`'standard' | 'flex' | null`) to the shared `LaunchParameters` interface in `src/resources/shared.ts`, following the inline-union `architecture` enum pattern. The shared interface is used by both `DevboxCreateParams` (request) and `DevboxView` (response).

This corresponds to the field now exposed in the OpenAPI spec (see runloopai/runloop). It is **hand-applied ahead of the next Stainless regeneration** so the alpha customer can use the field immediately; a subsequent Stainless run will converge to the same shape.

> Alpha soft-launch: `provisioning_tier` is intentionally **kept out of the public docs** — the field is stripped from the documented spec before it is pushed to the docs site (handled upstream in runloopai/runloop). It is present here in the SDK on purpose.

### Motivation

Soft-launch `provisioning_tier=flex` as an alpha for a single customer: usable via the SDK, absent from public docs.

### Testing

- Field added in alphabetical position (between `network_policy_id` and `required_services`) matching the generator's ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)