### PR TITLE
feat: add standalone HTTP/2 transport library

### DIFF
--- a/loadtest/sse-test.ts
+++ b/loadtest/sse-test.ts
@@ -1,0 +1,132 @@
+import http2 from 'node:http2';
+import { createH2Fetch } from '../src/lib/h2-transport/index.ts';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// Generate self-signed certs for the test server
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sse-test-'));
+const keyPath = path.join(tmpDir, 'key.pem');
+const certPath = path.join(tmpDir, 'cert.pem');
+
+execSync(
+  `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} ` +
+    `-days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+);
+
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+
+async function startSSEServer(): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve) => {
+    const server = http2.createSecureServer({
+      key: fs.readFileSync(keyPath),
+      cert: fs.readFileSync(certPath),
+    });
+
+    server.on('stream', (stream: http2.ServerHttp2Stream, headers) => {
+      if (headers[':path'] === '/v1/test/sse') {
+        stream.respond({
+          ':status': 200,
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+        });
+
+        const events = [
+          'data: {"id":1,"message":"hello"}\n\n',
+          'data: {"id":2,"message":"world"}\n\n',
+          'data: {"id":3,"message":"streaming done"}\n\n',
+        ];
+
+        let i = 0;
+        const interval = setInterval(() => {
+          if (i < events.length) {
+            stream.write(events[i]);
+            i++;
+          } else {
+            clearInterval(interval);
+            stream.end();
+          }
+        }, 50);
+      } else {
+        stream.respond({ ':status': 200, 'content-type': 'application/json' });
+        stream.end(JSON.stringify({ ok: true }));
+      }
+    });
+
+    server.listen(0, () => {
+      const port = (server.address() as any).port;
+      resolve({ port, close: () => server.close() });
+    });
+  });
+}
+
+async function main() {
+  const { port, close } = await startSSEServer();
+  console.log('SSE test server on port', port);
+
+  const h2Fetch = createH2Fetch();
+
+  // Test 1: Normal JSON request
+  console.log('\n--- Test 1: Normal JSON request ---');
+  const jsonResp = (await h2Fetch(`https://localhost:${port}/v1/test/json`, {
+    method: 'GET',
+    headers: {},
+  })) as any;
+  console.log('Status:', jsonResp.status);
+  const jsonBody = await jsonResp.json();
+  console.log('Body:', jsonBody);
+  console.log('PASS');
+
+  // Test 2: SSE streaming via getReader
+  console.log('\n--- Test 2: SSE streaming (getReader) ---');
+  const sseResp = (await h2Fetch(`https://localhost:${port}/v1/test/sse`, {
+    method: 'GET',
+    headers: { accept: 'text/event-stream' },
+  })) as any;
+  console.log('Status:', sseResp.status);
+  console.log('Content-Type:', sseResp.headers.get('content-type'));
+
+  const reader = sseResp.body.getReader();
+  const decoder = new TextDecoder();
+  const events: string[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const text = decoder.decode(value, { stream: true });
+    events.push(text);
+    console.log('  Chunk:', JSON.stringify(text));
+  }
+  reader.releaseLock();
+  console.log('Chunks received:', events.length);
+  console.log('PASS');
+
+  // Test 3: SSE via async iteration (Node 18+ fast path)
+  console.log('\n--- Test 3: SSE streaming (async iteration) ---');
+  const sseResp2 = (await h2Fetch(`https://localhost:${port}/v1/test/sse`, {
+    method: 'GET',
+    headers: { accept: 'text/event-stream' },
+  })) as any;
+
+  const iterEvents: string[] = [];
+  for await (const chunk of sseResp2.body) {
+    const text = decoder.decode(chunk, { stream: true });
+    iterEvents.push(text);
+    console.log('  Chunk:', JSON.stringify(text));
+  }
+  console.log('Chunks received:', iterEvents.length);
+  console.log('PASS');
+
+  console.log('\n=== All SSE tests PASSED ===');
+  close();
+
+  // Cleanup
+  fs.rmSync(tmpDir, { recursive: true });
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('FAIL:', err);
+  process.exit(1);
+});

--- a/loadtest/sse-test.ts
+++ b/loadtest/sse-test.ts
@@ -119,6 +119,7 @@ async function main() {
   console.log('PASS');
 
   console.log('\n=== All SSE tests PASSED ===');
+  await h2Fetch.close();
   close();
 
   // Cleanup

--- a/src/lib/h2-transport/headers.ts
+++ b/src/lib/h2-transport/headers.ts
@@ -1,0 +1,29 @@
+import type http2 from 'node:http2';
+
+/**
+ * Minimal Headers implementation satisfying the SDK's usage:
+ *   response.headers.get('content-type')
+ *   response.headers.entries()
+ */
+export class H2Headers {
+  private readonly map: Map<string, string>;
+
+  constructor(raw: http2.IncomingHttpHeaders) {
+    this.map = new Map();
+    for (const [key, value] of Object.entries(raw)) {
+      if (key.startsWith(':')) continue;
+      const normalized = Array.isArray(value) ? value.join(', ') : value;
+      if (normalized !== undefined) {
+        this.map.set(key.toLowerCase(), normalized);
+      }
+    }
+  }
+
+  get(name: string): string | null {
+    return this.map.get(name.toLowerCase()) ?? null;
+  }
+
+  entries(): IterableIterator<[string, string]> {
+    return this.map.entries();
+  }
+}

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -1,0 +1,107 @@
+/**
+ * A high-performance HTTP/2 fetch adapter built on Node's native `node:http2`.
+ *
+ * Replaces undici for HTTP/2 transport. Manages a pool of persistent H2 sessions
+ * per origin, multiplexing requests as concurrent streams. Each session handles up
+ * to the server-advertised MAX_CONCURRENT_STREAMS; the pool auto-scales between
+ * minConnections and maxConnections as load requires.
+ *
+ * Usage:
+ *   const fetch = createH2Fetch({ maxConnections: 20 });
+ *   const response = await fetch('https://api.example.com/v1/items', {
+ *     method: 'POST',
+ *     headers: { 'content-type': 'application/json' },
+ *     body: JSON.stringify({ name: 'test' }),
+ *   });
+ */
+
+import { Readable } from 'node:stream';
+import { H2Pool, type H2PoolOptions } from './pool';
+import { MultipartBody } from '../../_shims/MultipartBody';
+import { type Fetch } from '../../core';
+
+const MIN_NODE_MAJOR = 18;
+
+function checkNodeVersion(): void {
+  const match = process.versions?.node?.match(/^(\d+)/);
+  if (!match?.[1]) return; // non-Node runtime, let it fail naturally
+  const major = parseInt(match[1], 10);
+  if (major < MIN_NODE_MAJOR) {
+    throw new Error(
+      `h2-transport requires Node.js ${MIN_NODE_MAJOR} or later (found ${process.versions.node}). ` +
+        `The HTTP/2 transport depends on node:stream/web which is not available in older versions.`,
+    );
+  }
+}
+
+export type { H2PoolOptions as H2FetchOptions };
+
+function normalizeBody(body: unknown): string | Buffer | null {
+  if (body == null) return null;
+  if (typeof body === 'string') return body;
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof MultipartBody) return normalizeBody((body as MultipartBody).body);
+  if (body instanceof Readable) {
+    // Multipart bodies arrive as Node Readable. For H2, we need to buffer them
+    // since session.request() takes string | Buffer. The Readable is a
+    // FormDataEncoder stream with a known content-length, so buffering is safe.
+    // Streaming uploads could be added later if needed.
+    throw new Error(
+      'h2-transport: streaming request bodies (Readable) are not yet supported. ' +
+        'Use a string or Buffer body.',
+    );
+  }
+  if (ArrayBuffer.isView(body)) return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  if (body instanceof ArrayBuffer) return Buffer.from(body);
+  return String(body);
+}
+
+/**
+ * Build a fetch adapter backed by native HTTP/2 connection pools.
+ *
+ * Compatible with the SDK's `makeHttp2Fetch` interface: called with no arguments
+ * for `http2: true`, or with options for `http2: <H2FetchOptions>`.
+ */
+export function createH2Fetch(options?: H2PoolOptions): Fetch {
+  checkNodeVersion();
+  const pools = new Map<string, H2Pool>();
+
+  function getPool(origin: string): H2Pool {
+    let pool = pools.get(origin);
+    if (!pool) {
+      pool = new H2Pool(origin, options);
+      pools.set(origin, pool);
+    }
+    return pool;
+  }
+
+  return async (url, init) => {
+    const {
+      agent: _ignored, // node-fetch artifact injected by core.ts
+      body: rawBody,
+      signal,
+      method = 'GET',
+      headers: rawHeaders,
+    } = (init ?? {}) as any;
+
+    const parsed = typeof url === 'string' ? new URL(url) : new URL(url.toString());
+    const path = parsed.pathname + parsed.search;
+    const body = normalizeBody(rawBody);
+
+    const reqHeaders: Record<string, string> = {};
+    if (rawHeaders) {
+      if (typeof rawHeaders.entries === 'function') {
+        for (const [k, v] of rawHeaders.entries()) {
+          reqHeaders[k.toLowerCase()] = v;
+        }
+      } else {
+        for (const [k, v] of Object.entries(rawHeaders as Record<string, string>)) {
+          reqHeaders[k.toLowerCase()] = v;
+        }
+      }
+    }
+
+    const pool = getPool(parsed.origin);
+    return pool.request(path, method.toUpperCase(), reqHeaders, body, signal) as any;
+  };
+}

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -40,20 +40,23 @@ export type H2Fetch = Fetch & {
   close: () => Promise<void>;
 };
 
-function normalizeBody(body: unknown): string | Buffer | null {
+async function bufferReadable(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+async function normalizeBody(body: unknown): Promise<string | Buffer | null> {
   if (body == null) return null;
   if (typeof body === 'string') return body;
   if (Buffer.isBuffer(body)) return body;
   if (body instanceof MultipartBody) return normalizeBody((body as MultipartBody).body);
   if (body instanceof Readable) {
-    // Multipart bodies arrive as Node Readable. For H2, we need to buffer them
-    // since session.request() takes string | Buffer. The Readable is a
-    // FormDataEncoder stream with a known content-length, so buffering is safe.
-    // Streaming uploads could be added later if needed.
-    throw new Error(
-      'h2-transport: streaming request bodies (Readable) are not yet supported. ' +
-        'Use a string or Buffer body.',
-    );
+    // Multipart bodies arrive as a FormDataEncoder Readable with a known
+    // content-length. session.request() takes string | Buffer, so buffer here.
+    return bufferReadable(body);
   }
   if (ArrayBuffer.isView(body)) return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
   if (body instanceof ArrayBuffer) return Buffer.from(body);
@@ -90,7 +93,7 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
 
     const parsed = typeof url === 'string' ? new URL(url) : new URL(url.toString());
     const path = parsed.pathname + parsed.search;
-    const body = normalizeBody(rawBody);
+    const body = await normalizeBody(rawBody);
 
     const reqHeaders: Record<string, string> = {};
     if (rawHeaders) {

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -36,6 +36,10 @@ function checkNodeVersion(): void {
 
 export type { H2PoolOptions as H2FetchOptions };
 
+export type H2Fetch = Fetch & {
+  close: () => Promise<void>;
+};
+
 function normalizeBody(body: unknown): string | Buffer | null {
   if (body == null) return null;
   if (typeof body === 'string') return body;
@@ -62,7 +66,7 @@ function normalizeBody(body: unknown): string | Buffer | null {
  * Compatible with the SDK's `makeHttp2Fetch` interface: called with no arguments
  * for `http2: true`, or with options for `http2: <H2FetchOptions>`.
  */
-export function createH2Fetch(options?: H2PoolOptions): Fetch {
+export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
   checkNodeVersion();
   const pools = new Map<string, H2Pool>();
 
@@ -75,7 +79,7 @@ export function createH2Fetch(options?: H2PoolOptions): Fetch {
     return pool;
   }
 
-  return async (url, init) => {
+  const h2Fetch = (async (url, init) => {
     const {
       agent: _ignored, // node-fetch artifact injected by core.ts
       body: rawBody,
@@ -103,5 +107,13 @@ export function createH2Fetch(options?: H2PoolOptions): Fetch {
 
     const pool = getPool(parsed.origin);
     return pool.request(path, method.toUpperCase(), reqHeaders, body, signal) as any;
+  }) as H2Fetch;
+
+  h2Fetch.close = async () => {
+    const closeTasks = [...pools.values()].map((pool) => pool.close());
+    pools.clear();
+    await Promise.all(closeTasks);
   };
+
+  return h2Fetch;
 }

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -47,9 +47,16 @@ export class H2Pool {
     if (this._initialized) return;
     if (this._initPromise) return this._initPromise;
 
-    this._initPromise = this._createInitialSessions();
-    await this._initPromise;
-    this._initialized = true;
+    const attempt = this._createInitialSessions();
+    this._initPromise = attempt;
+    try {
+      await attempt;
+      this._initialized = true;
+    } catch (err) {
+      // Don't cache the failure — let subsequent requests retry initialization.
+      if (this._initPromise === attempt) this._initPromise = null;
+      throw err;
+    }
   }
 
   private async _createInitialSessions(): Promise<void> {

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -1,0 +1,228 @@
+import { H2Session, SessionState, type H2SessionOptions } from './session';
+import type { H2Response } from './response';
+
+export interface H2PoolOptions extends H2SessionOptions {
+  minConnections?: number;
+  maxConnections?: number;
+}
+
+const DEFAULT_MIN_CONNECTIONS = 4;
+const DEFAULT_MAX_CONNECTIONS = 20;
+
+interface QueuedRequest {
+  path: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | Buffer | null;
+  signal: AbortSignal | null | undefined;
+  resolve: (response: H2Response) => void;
+  reject: (error: Error) => void;
+}
+
+export class H2Pool {
+  private readonly _origin: string;
+  private readonly _opts: H2PoolOptions;
+  private readonly _sessions: H2Session[] = [];
+  private readonly _queue: QueuedRequest[] = [];
+  private _initialized = false;
+  private _initPromise: Promise<void> | null = null;
+  private _growing = false;
+  private _closed = false;
+
+  constructor(origin: string, opts: H2PoolOptions = {}) {
+    this._origin = origin;
+    this._opts = opts;
+  }
+
+  private get _minConnections(): number {
+    return this._opts.minConnections ?? DEFAULT_MIN_CONNECTIONS;
+  }
+
+  private get _maxConnections(): number {
+    return this._opts.maxConnections ?? DEFAULT_MAX_CONNECTIONS;
+  }
+
+  private async _initialize(): Promise<void> {
+    if (this._initialized) return;
+    if (this._initPromise) return this._initPromise;
+
+    this._initPromise = this._createInitialSessions();
+    await this._initPromise;
+    this._initialized = true;
+  }
+
+  private async _createInitialSessions(): Promise<void> {
+    const tasks: Promise<unknown>[] = [];
+    for (let i = 0; i < this._minConnections; i++) {
+      tasks.push(this._addSession());
+    }
+    const results = await Promise.allSettled(tasks);
+    const anyOk = results.some((r) => r.status === 'fulfilled');
+    if (!anyOk) {
+      const first = results[0] as PromiseRejectedResult;
+      throw first.reason;
+    }
+  }
+
+  private async _addSession(): Promise<H2Session> {
+    const session = new H2Session(this._origin, this._opts);
+
+    session.onAvailable = () => this._drainQueue();
+
+    session.onClose = (s) => {
+      const idx = this._sessions.indexOf(s);
+      if (idx !== -1) this._sessions.splice(idx, 1);
+
+      if (!this._closed && this._sessions.length < this._minConnections) {
+        this._addSession().catch(() => {});
+      }
+    };
+
+    await session.connect();
+    this._sessions.push(session);
+    return session;
+  }
+
+  /**
+   * Dispatch queued requests to available sessions.
+   *
+   * Each dispatch calls session.request() whose Promise executor runs
+   * synchronously, incrementing activeStreams before yielding. This prevents
+   * the thundering herd where all callers see 0 active streams.
+   */
+  private _drainQueue(): void {
+    while (this._queue.length > 0) {
+      const session = this._findAvailable();
+      if (!session) break;
+      const req = this._queue.shift()!;
+      this._dispatchToSession(session, req.path, req.method, req.headers, req.body, req.signal)
+        .then(req.resolve, req.reject);
+    }
+
+    if (this._queue.length > 0 && !this._growing) {
+      this._growPool();
+    }
+  }
+
+  private _findAvailable(): H2Session | null {
+    let best: H2Session | null = null;
+    for (const s of this._sessions) {
+      if (!s.available) continue;
+      if (!best || s.activeStreams < best.activeStreams) {
+        best = s;
+      }
+    }
+    return best;
+  }
+
+  /**
+   * Dispatch a request to a session, retrying once on GOAWAY race.
+   *
+   * session.request()'s Promise executor increments activeStreams
+   * synchronously, so the caller's stream slot is reserved before any yield.
+   */
+  private async _dispatchToSession(
+    session: H2Session,
+    path: string,
+    method: string,
+    headers: Record<string, string>,
+    body: string | Buffer | null,
+    signal?: AbortSignal | null,
+  ): Promise<H2Response> {
+    try {
+      return await session.request(path, method, headers, body, signal);
+    } catch (err: any) {
+      if (session.state !== SessionState.READY) {
+        // Session went away (GOAWAY, etc). Re-enter the pool for a retry.
+        return this._enqueueRequest(path, method, headers, body, signal);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Grow the pool one session at a time until the queue is drained or max is hit.
+   * Serialized so we don't thundering-herd connect attempts.
+   */
+  private async _growPool(): Promise<void> {
+    if (this._growing) return;
+    this._growing = true;
+    try {
+      while (this._queue.length > 0 && this._sessions.length < this._maxConnections) {
+        await this._addSession();
+        this._drainQueue();
+      }
+    } catch {
+      // Connection failed; remaining requests stay queued for existing sessions
+    } finally {
+      this._growing = false;
+    }
+  }
+
+  /**
+   * Send a request through the pool.
+   *
+   * NOT async: when the pool is initialized and a session is available,
+   * session.request() is called synchronously. Its Promise executor
+   * increments activeStreams before yielding, which prevents the microtask
+   * scheduling bug where all concurrent callers see 0 active streams and
+   * all get routed to the same sessions.
+   */
+  request(
+    path: string,
+    method: string,
+    headers: Record<string, string>,
+    body: string | Buffer | null,
+    signal?: AbortSignal | null,
+  ): Promise<H2Response> {
+    if (this._closed) return Promise.reject(new Error('Pool is closed'));
+
+    // Fast path: pool initialized, session available — dispatch synchronously
+    if (this._initialized) {
+      const session = this._findAvailable();
+      if (session) {
+        return this._dispatchToSession(session, path, method, headers, body, signal);
+      }
+    }
+
+    // Slow path: need to initialize or wait for capacity
+    return this._enqueueRequest(path, method, headers, body, signal);
+  }
+
+  private async _enqueueRequest(
+    path: string,
+    method: string,
+    headers: Record<string, string>,
+    body: string | Buffer | null,
+    signal?: AbortSignal | null,
+  ): Promise<H2Response> {
+    await this._initialize();
+
+    // After init, try the fast path before queuing
+    const session = this._findAvailable();
+    if (session) {
+      return this._dispatchToSession(session, path, method, headers, body, signal);
+    }
+
+    return new Promise<H2Response>((resolve, reject) => {
+      this._queue.push({ path, method, headers, body, signal, resolve, reject });
+
+      if (!this._growing && this._sessions.length < this._maxConnections) {
+        this._growPool();
+      }
+    });
+  }
+
+  async close(): Promise<void> {
+    this._closed = true;
+    for (const s of this._sessions) {
+      s.close();
+    }
+    this._sessions.length = 0;
+
+    for (const req of this._queue) {
+      req.reject(new Error('Pool is closed'));
+    }
+    this._queue.length = 0;
+  }
+}

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -8,6 +8,7 @@ export interface H2PoolOptions extends H2SessionOptions {
 
 const DEFAULT_MIN_CONNECTIONS = 4;
 const DEFAULT_MAX_CONNECTIONS = 20;
+const RETRYABLE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
 
 interface QueuedRequest {
   path: string;
@@ -95,8 +96,10 @@ export class H2Pool {
       const session = this._findAvailable();
       if (!session) break;
       const req = this._queue.shift()!;
-      this._dispatchToSession(session, req.path, req.method, req.headers, req.body, req.signal)
-        .then(req.resolve, req.reject);
+      this._dispatchToSession(session, req.path, req.method, req.headers, req.body, req.signal).then(
+        req.resolve,
+        req.reject,
+      );
     }
 
     if (this._queue.length > 0 && !this._growing) {
@@ -132,7 +135,7 @@ export class H2Pool {
     try {
       return await session.request(path, method, headers, body, signal);
     } catch (err: any) {
-      if (session.state !== SessionState.READY) {
+      if (session.state !== SessionState.READY && RETRYABLE_METHODS.has(method)) {
         // Session went away (GOAWAY, etc). Re-enter the pool for a retry.
         return this._enqueueRequest(path, method, headers, body, signal);
       }
@@ -215,14 +218,14 @@ export class H2Pool {
 
   async close(): Promise<void> {
     this._closed = true;
-    for (const s of this._sessions) {
-      s.close();
-    }
+    const sessions = [...this._sessions];
     this._sessions.length = 0;
 
     for (const req of this._queue) {
       req.reject(new Error('Pool is closed'));
     }
     this._queue.length = 0;
+
+    await Promise.all(sessions.map((s) => s.close()));
   }
 }

--- a/src/lib/h2-transport/response.ts
+++ b/src/lib/h2-transport/response.ts
@@ -1,3 +1,4 @@
+import { Blob } from 'node:buffer';
 import { H2Headers } from './headers';
 
 /**
@@ -14,12 +15,7 @@ export class H2Response {
   private _bodyConsumed = false;
   private _bodyBytes: Buffer | null = null;
 
-  constructor(
-    status: number,
-    headers: H2Headers,
-    body: ReadableStream<Uint8Array>,
-    url: string,
-  ) {
+  constructor(status: number, headers: H2Headers, body: ReadableStream<Uint8Array>, url: string) {
     this.status = status;
     this.ok = status >= 200 && status < 300;
     this.url = url;
@@ -57,5 +53,10 @@ export class H2Response {
   async arrayBuffer(): Promise<ArrayBuffer> {
     const buf = await this._consumeBody();
     return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+  }
+
+  async blob(): Promise<Blob> {
+    const buf = await this._consumeBody();
+    return new Blob([buf], { type: this.headers.get('content-type') ?? undefined });
   }
 }

--- a/src/lib/h2-transport/response.ts
+++ b/src/lib/h2-transport/response.ts
@@ -1,0 +1,61 @@
+import { H2Headers } from './headers';
+
+/**
+ * Minimal Response wrapper satisfying the SDK's usage:
+ *   .status, .ok, .url, .headers, .body, .json(), .text()
+ */
+export class H2Response {
+  readonly status: number;
+  readonly ok: boolean;
+  readonly url: string;
+  readonly headers: H2Headers;
+  readonly body: ReadableStream<Uint8Array>;
+
+  private _bodyConsumed = false;
+  private _bodyBytes: Buffer | null = null;
+
+  constructor(
+    status: number,
+    headers: H2Headers,
+    body: ReadableStream<Uint8Array>,
+    url: string,
+  ) {
+    this.status = status;
+    this.ok = status >= 200 && status < 300;
+    this.url = url;
+    this.headers = headers;
+    this.body = body;
+  }
+
+  private async _consumeBody(): Promise<Buffer> {
+    if (this._bodyBytes !== null) return this._bodyBytes;
+    if (this._bodyConsumed) throw new Error('Body already consumed');
+    this._bodyConsumed = true;
+
+    const chunks: Buffer[] = [];
+    const reader = this.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(Buffer.isBuffer(value) ? value : Buffer.from(value));
+    }
+    reader.releaseLock();
+    this._bodyBytes = Buffer.concat(chunks);
+    return this._bodyBytes;
+  }
+
+  async text(): Promise<string> {
+    const buf = await this._consumeBody();
+    return buf.toString('utf-8');
+  }
+
+  async json(): Promise<any> {
+    const text = await this.text();
+    return JSON.parse(text);
+  }
+
+  async arrayBuffer(): Promise<ArrayBuffer> {
+    const buf = await this._consumeBody();
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+  }
+}

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -158,9 +158,9 @@ export class H2Session {
         if (this._state === SessionState.DRAINING && this._activeStreams === 0) {
           this._close();
         }
-        if (this.available) {
-          this.onAvailable?.();
-        }
+        // Always notify the pool so it can route queued work to other sessions
+        // (or grow) when this session is draining/closed and can't take more.
+        this.onAvailable?.();
       };
 
       stream.once('close', cleanup);

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -19,6 +19,8 @@ export interface H2SessionOptions {
 
 const DEFAULT_CONNECT_TIMEOUT = 30_000;
 
+const createAbortError = (): Error => Object.assign(new Error('Request aborted'), { name: 'AbortError' });
+
 export class H2Session {
   readonly origin: string;
 
@@ -58,17 +60,21 @@ export class H2Session {
       this._session = session;
 
       const timeout = setTimeout(() => {
-        session.destroy(new Error(`H2 connect timeout after ${this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT}ms`));
+        session.destroy(
+          new Error(`H2 connect timeout after ${this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT}ms`),
+        );
       }, this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT);
 
       session.on('connect', () => {
         clearTimeout(timeout);
-        const serverMax = session.remoteSettings?.maxConcurrentStreams;
-        if (serverMax != null && !this._opts.maxConcurrentStreams) {
-          this._maxConcurrentStreams = serverMax;
-        }
         this._state = SessionState.READY;
         resolve();
+      });
+
+      session.on('remoteSettings', (settings) => {
+        if (settings.maxConcurrentStreams != null && !this._opts.maxConcurrentStreams) {
+          this._maxConcurrentStreams = settings.maxConcurrentStreams;
+        }
       });
 
       session.on('error', (err) => {
@@ -125,10 +131,11 @@ export class H2Session {
       this._activeStreams++;
 
       let settled = false;
+      let cleaned = false;
 
       const onAbort = () => {
-        if (!settled) {
-          stream.destroy(new Error('Request aborted'));
+        if (!cleaned) {
+          stream.destroy(createAbortError());
         }
       };
 
@@ -137,13 +144,15 @@ export class H2Session {
           stream.on('error', () => {});
           stream.destroy();
           this._activeStreams--;
-          reject(new Error('Request aborted'));
+          reject(createAbortError());
           return;
         }
         signal.addEventListener('abort', onAbort, { once: true });
       }
 
       const cleanup = () => {
+        if (cleaned) return;
+        cleaned = true;
         this._activeStreams--;
         if (signal) signal.removeEventListener('abort', onAbort);
         if (this._state === SessionState.DRAINING && this._activeStreams === 0) {
@@ -153,6 +162,8 @@ export class H2Session {
           this.onAvailable?.();
         }
       };
+
+      stream.once('close', cleanup);
 
       stream.on('error', (err) => {
         if (!settled) {
@@ -204,8 +215,17 @@ export class H2Session {
     });
   }
 
-  close(): void {
-    this._close();
+  close(): Promise<void> {
+    const session = this._session;
+    if (!session || session.destroyed) {
+      this._close();
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      session.once('close', resolve);
+      this._close();
+    });
   }
 
   private _close(): void {

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -1,0 +1,218 @@
+import http2 from 'node:http2';
+import type tls from 'node:tls';
+import { ReadableStream } from 'node:stream/web';
+import { H2Headers } from './headers';
+import { H2Response } from './response';
+
+export const enum SessionState {
+  CONNECTING,
+  READY,
+  DRAINING,
+  CLOSED,
+}
+
+export interface H2SessionOptions {
+  connectTimeout?: number;
+  maxConcurrentStreams?: number;
+  tlsOptions?: tls.ConnectionOptions;
+}
+
+const DEFAULT_CONNECT_TIMEOUT = 30_000;
+
+export class H2Session {
+  readonly origin: string;
+
+  private _state = SessionState.CONNECTING;
+  private _activeStreams = 0;
+  private _maxConcurrentStreams: number;
+  private _session: http2.ClientHttp2Session | null = null;
+  private _connectPromise: Promise<void> | null = null;
+  private readonly _opts: H2SessionOptions;
+
+  /** Called by the pool when a stream slot frees up. */
+  onAvailable: (() => void) | null = null;
+  /** Called when this session closes (goaway completed, error, etc). */
+  onClose: ((session: H2Session) => void) | null = null;
+
+  constructor(origin: string, opts: H2SessionOptions = {}) {
+    this.origin = origin;
+    this._opts = opts;
+    this._maxConcurrentStreams = opts.maxConcurrentStreams ?? 100;
+  }
+
+  get state(): SessionState {
+    return this._state;
+  }
+  get activeStreams(): number {
+    return this._activeStreams;
+  }
+  get available(): boolean {
+    return this._state === SessionState.READY && this._activeStreams < this._maxConcurrentStreams;
+  }
+
+  connect(): Promise<void> {
+    if (this._connectPromise) return this._connectPromise;
+
+    this._connectPromise = new Promise<void>((resolve, reject) => {
+      const session = http2.connect(this.origin, this._opts.tlsOptions);
+      this._session = session;
+
+      const timeout = setTimeout(() => {
+        session.destroy(new Error(`H2 connect timeout after ${this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT}ms`));
+      }, this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT);
+
+      session.on('connect', () => {
+        clearTimeout(timeout);
+        const serverMax = session.remoteSettings?.maxConcurrentStreams;
+        if (serverMax != null && !this._opts.maxConcurrentStreams) {
+          this._maxConcurrentStreams = serverMax;
+        }
+        this._state = SessionState.READY;
+        resolve();
+      });
+
+      session.on('error', (err) => {
+        clearTimeout(timeout);
+        if (this._state === SessionState.CONNECTING) {
+          this._state = SessionState.CLOSED;
+          reject(err);
+        } else {
+          this._state = SessionState.CLOSED;
+          this.onClose?.(this);
+        }
+      });
+
+      session.on('goaway', () => {
+        this._state = SessionState.DRAINING;
+        if (this._activeStreams === 0) {
+          this._close();
+        }
+      });
+
+      session.on('close', () => {
+        if (this._state !== SessionState.CLOSED) {
+          this._state = SessionState.CLOSED;
+          this.onClose?.(this);
+        }
+      });
+    });
+
+    return this._connectPromise;
+  }
+
+  request(
+    path: string,
+    method: string,
+    headers: Record<string, string>,
+    body: string | Buffer | null,
+    signal?: AbortSignal | null,
+  ): Promise<H2Response> {
+    if (!this._session || this._state === SessionState.CLOSED) {
+      return Promise.reject(new Error('H2 session is closed'));
+    }
+    if (this._state === SessionState.DRAINING) {
+      return Promise.reject(new Error('H2 session is draining'));
+    }
+
+    return new Promise<H2Response>((resolve, reject) => {
+      const h2Headers: http2.OutgoingHttpHeaders = {
+        ':method': method,
+        ':path': path,
+        ...headers,
+      };
+
+      const stream = this._session!.request(h2Headers);
+      this._activeStreams++;
+
+      let settled = false;
+
+      const onAbort = () => {
+        if (!settled) {
+          stream.destroy(new Error('Request aborted'));
+        }
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          stream.on('error', () => {});
+          stream.destroy();
+          this._activeStreams--;
+          reject(new Error('Request aborted'));
+          return;
+        }
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+
+      const cleanup = () => {
+        this._activeStreams--;
+        if (signal) signal.removeEventListener('abort', onAbort);
+        if (this._state === SessionState.DRAINING && this._activeStreams === 0) {
+          this._close();
+        }
+        if (this.available) {
+          this.onAvailable?.();
+        }
+      };
+
+      stream.on('error', (err) => {
+        if (!settled) {
+          settled = true;
+          cleanup();
+          reject(err);
+        }
+      });
+
+      stream.on('response', (responseHeaders) => {
+        settled = true;
+        const status = responseHeaders[':status'] as number;
+        const h2headers = new H2Headers(responseHeaders);
+
+        const responseBody = new ReadableStream<Uint8Array>({
+          start(controller) {
+            stream.on('data', (chunk: Buffer) => {
+              controller.enqueue(chunk);
+            });
+            stream.on('end', () => {
+              controller.close();
+              cleanup();
+            });
+            stream.on('error', (err) => {
+              try {
+                controller.error(err);
+              } catch {
+                // controller may already be closed
+              }
+              cleanup();
+            });
+          },
+          cancel() {
+            stream.destroy();
+            cleanup();
+          },
+        });
+
+        const url = `${this.origin}${path}`;
+        resolve(new H2Response(status, h2headers, responseBody, url));
+      });
+
+      // Send the request body
+      if (body != null) {
+        stream.end(body);
+      } else {
+        stream.end();
+      }
+    });
+  }
+
+  close(): void {
+    this._close();
+  }
+
+  private _close(): void {
+    this._state = SessionState.CLOSED;
+    if (this._session && !this._session.destroyed) {
+      this._session.close();
+    }
+    this.onClose?.(this);
+  }
+}

--- a/tests/lib/h2-transport.test.ts
+++ b/tests/lib/h2-transport.test.ts
@@ -36,6 +36,7 @@ function startTestServer(
   handler: (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => void,
 ): Promise<{ port: number; close: () => Promise<void> }> {
   return new Promise((resolve) => {
+    const sessions = new Set<http2.ServerHttp2Session>();
     const server = http2.createSecureServer({
       key: fs.readFileSync(keyPath),
       cert: fs.readFileSync(certPath),
@@ -44,12 +45,20 @@ function startTestServer(
       stream.on('error', () => {});
       handler(stream, headers);
     });
-    server.on('session', (session) => { session.on('error', () => {}); });
+    server.on('session', (session) => {
+      sessions.add(session);
+      session.on('error', () => {});
+      session.on('close', () => sessions.delete(session));
+    });
     server.listen(0, () => {
       const port = (server.address() as any).port;
       resolve({
         port,
-        close: () => new Promise<void>((res) => server.close(() => res())),
+        close: () =>
+          new Promise<void>((res) => {
+            for (const session of sessions) session.close();
+            server.close(() => res());
+          }),
       });
     });
   });

--- a/tests/lib/h2-transport.test.ts
+++ b/tests/lib/h2-transport.test.ts
@@ -463,4 +463,17 @@ describe('normalizeBody', () => {
     const body = await resp.json();
     expect(body.echoed).toBe('buffer data');
   });
+
+  test('Readable body is buffered', async () => {
+    const { Readable } = await import('node:stream');
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const stream = Readable.from([Buffer.from('chunk-1|'), Buffer.from('chunk-2')]);
+    const resp = (await h2Fetch(`https://localhost:${server.port}/echo`, {
+      method: 'POST',
+      headers: {},
+      body: stream,
+    })) as any;
+    const body = await resp.json();
+    expect(body.echoed).toBe('chunk-1|chunk-2');
+  });
 });

--- a/tests/lib/h2-transport.test.ts
+++ b/tests/lib/h2-transport.test.ts
@@ -1,0 +1,457 @@
+import http2 from 'node:http2';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { H2Headers } from '../../src/lib/h2-transport/headers';
+import { H2Response } from '../../src/lib/h2-transport/response';
+import { H2Session, SessionState } from '../../src/lib/h2-transport/session';
+import { H2Pool } from '../../src/lib/h2-transport/pool';
+import { createH2Fetch } from '../../src/lib/h2-transport/index';
+
+// ---------------------------------------------------------------------------
+// Shared test server infrastructure
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+let keyPath: string;
+let certPath: string;
+const testTls = { rejectUnauthorized: false };
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'h2-test-'));
+  keyPath = path.join(tmpDir, 'key.pem');
+  certPath = path.join(tmpDir, 'cert.pem');
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -keyout ${keyPath} -out ${certPath} ` +
+      `-days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function startTestServer(
+  handler: (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => void,
+): Promise<{ port: number; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http2.createSecureServer({
+      key: fs.readFileSync(keyPath),
+      cert: fs.readFileSync(certPath),
+    });
+    server.on('stream', (stream, headers) => {
+      stream.on('error', () => {});
+      handler(stream, headers);
+    });
+    server.on('session', (session) => { session.on('error', () => {}); });
+    server.listen(0, () => {
+      const port = (server.address() as any).port;
+      resolve({
+        port,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+function jsonHandler(stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) {
+  const reqPath = headers[':path'] as string;
+  const method = headers[':method'] as string;
+
+  if (reqPath === '/echo' && method === 'POST') {
+    const chunks: Buffer[] = [];
+    stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+    stream.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf-8');
+      stream.respond({ ':status': 200, 'content-type': 'application/json' });
+      stream.end(JSON.stringify({ echoed: body }));
+    });
+    return;
+  }
+
+  if (reqPath === '/sse') {
+    stream.respond({ ':status': 200, 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+    const events = [
+      'data: {"id":1,"msg":"hello"}\n\n',
+      'data: {"id":2,"msg":"world"}\n\n',
+    ];
+    let i = 0;
+    const interval = setInterval(() => {
+      if (i < events.length) {
+        stream.write(events[i]!);
+        i++;
+      } else {
+        clearInterval(interval);
+        stream.end();
+      }
+    }, 20);
+    return;
+  }
+
+  // Default: return JSON with request info
+  stream.respond({ ':status': 200, 'content-type': 'application/json', 'x-custom': 'test-value' });
+  stream.end(JSON.stringify({ path: reqPath, method }));
+}
+
+// ---------------------------------------------------------------------------
+// H2Headers
+// ---------------------------------------------------------------------------
+
+describe('H2Headers', () => {
+  test('strips pseudo-headers and lowercases keys', () => {
+    const h = new H2Headers({ ':status': '200' as any, 'Content-Type': 'application/json', 'X-Custom': 'val' });
+    expect(h.get('content-type')).toBe('application/json');
+    expect(h.get('x-custom')).toBe('val');
+    expect(h.get(':status')).toBeNull();
+  });
+
+  test('joins array values with comma', () => {
+    const h = new H2Headers({ 'set-cookie': ['a=1', 'b=2'] } as any);
+    expect(h.get('set-cookie')).toBe('a=1, b=2');
+  });
+
+  test('get is case-insensitive', () => {
+    const h = new H2Headers({ 'Content-Type': 'text/plain' });
+    expect(h.get('CONTENT-TYPE')).toBe('text/plain');
+    expect(h.get('content-type')).toBe('text/plain');
+  });
+
+  test('entries iterates all non-pseudo headers', () => {
+    const h = new H2Headers({ ':status': '200' as any, 'a': '1', 'b': '2' });
+    const entries = [...h.entries()];
+    expect(entries).toEqual([['a', '1'], ['b', '2']]);
+  });
+
+  test('returns null for missing headers', () => {
+    const h = new H2Headers({});
+    expect(h.get('x-missing')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H2Response
+// ---------------------------------------------------------------------------
+
+describe('H2Response', () => {
+  function makeResponse(data: string, status = 200): H2Response {
+    const { ReadableStream } = require('node:stream/web');
+    const body = new ReadableStream({
+      start(controller: any) {
+        controller.enqueue(Buffer.from(data));
+        controller.close();
+      },
+    });
+    return new H2Response(status, new H2Headers({ 'content-type': 'application/json' }), body, 'https://test/');
+  }
+
+  test('.status and .ok', () => {
+    expect(makeResponse('{}', 200).ok).toBe(true);
+    expect(makeResponse('{}', 201).ok).toBe(true);
+    expect(makeResponse('{}', 400).ok).toBe(false);
+    expect(makeResponse('{}', 500).ok).toBe(false);
+    expect(makeResponse('{}', 204).status).toBe(204);
+  });
+
+  test('.json() parses response body', async () => {
+    const resp = makeResponse('{"key":"value"}');
+    expect(await resp.json()).toEqual({ key: 'value' });
+  });
+
+  test('.text() returns body as string', async () => {
+    const resp = makeResponse('hello world');
+    expect(await resp.text()).toBe('hello world');
+  });
+
+  test('.json() and .text() can be called multiple times', async () => {
+    const resp = makeResponse('{"a":1}');
+    expect(await resp.json()).toEqual({ a: 1 });
+    expect(await resp.text()).toBe('{"a":1}');
+  });
+
+  test('.body is a readable stream', async () => {
+    const resp = makeResponse('streamed');
+    const reader = resp.body.getReader();
+    const { value, done } = await reader.read();
+    expect(done).toBe(false);
+    expect(Buffer.from(value!).toString()).toBe('streamed');
+    reader.releaseLock();
+  });
+
+  test('.url and .headers are set', () => {
+    const resp = makeResponse('{}');
+    expect(resp.url).toBe('https://test/');
+    expect(resp.headers.get('content-type')).toBe('application/json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H2Session
+// ---------------------------------------------------------------------------
+
+describe('H2Session', () => {
+  let server: { port: number; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    server = await startTestServer(jsonHandler);
+  });
+
+  afterAll(async () => { await server.close(); });
+
+  test('connects and reaches READY state', async () => {
+    const session = new H2Session(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await session.connect();
+    expect(session.state).toBe(SessionState.READY);
+    expect(session.available).toBe(true);
+    session.close();
+  });
+
+  test('sends GET and receives JSON response', async () => {
+    const session = new H2Session(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await session.connect();
+    const resp = await session.request('/info', 'GET', {}, null);
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.path).toBe('/info');
+    expect(body.method).toBe('GET');
+    session.close();
+  });
+
+  test('sends POST with body', async () => {
+    const session = new H2Session(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await session.connect();
+    const resp = await session.request('/echo', 'POST', { 'content-type': 'application/json' }, '{"test":true}');
+    const body = await resp.json();
+    expect(body.echoed).toBe('{"test":true}');
+    session.close();
+  });
+
+  test('tracks activeStreams count', async () => {
+    const session = new H2Session(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await session.connect();
+    expect(session.activeStreams).toBe(0);
+
+    const p1 = session.request('/info', 'GET', {}, null);
+    // activeStreams incremented synchronously in the Promise executor
+    expect(session.activeStreams).toBe(1);
+
+    await p1;
+    // Stream is still active until body is consumed
+    expect(session.activeStreams).toBeGreaterThanOrEqual(0);
+    session.close();
+  });
+
+  test('rejects request when closed', async () => {
+    const session = new H2Session(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await session.connect();
+    session.close();
+    await expect(session.request('/info', 'GET', {}, null)).rejects.toThrow('closed');
+  });
+
+  test('abort signal cancels request', async () => {
+    const session = new H2Session(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await session.connect();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(session.request('/info', 'GET', {}, null, controller.signal)).rejects.toThrow('aborted');
+    session.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H2Pool
+// ---------------------------------------------------------------------------
+
+describe('H2Pool', () => {
+  let server: { port: number; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    server = await startTestServer(jsonHandler);
+  });
+
+  afterAll(async () => { await server.close(); });
+
+  test('dispatches multiple requests', async () => {
+    const pool = new H2Pool(`https://localhost:${server.port}`, { minConnections: 1, maxConnections: 1, tlsOptions: testTls });
+    const resp1 = await pool.request('/item/0', 'GET', {}, null);
+    expect(resp1.status).toBe(200);
+    expect((await resp1.json()).path).toBe('/item/0');
+
+    const resp2 = await pool.request('/item/1', 'GET', {}, null);
+    expect(resp2.status).toBe(200);
+    expect((await resp2.json()).path).toBe('/item/1');
+
+    const resp3 = await pool.request('/item/2', 'GET', {}, null);
+    expect(resp3.status).toBe(200);
+    expect((await resp3.json()).path).toBe('/item/2');
+    await pool.close();
+  });
+
+  test('queues requests when all sessions are at capacity', async () => {
+    const pool = new H2Pool(`https://localhost:${server.port}`, {
+      minConnections: 1,
+      maxConnections: 1,
+      maxConcurrentStreams: 2,
+      tlsOptions: testTls,
+    });
+    const responses = await Promise.all(
+      Array.from({ length: 4 }, (_, i) =>
+        pool.request(`/item/${i}`, 'GET', {}, null),
+      ),
+    );
+    expect(responses.length).toBe(4);
+    for (const resp of responses) {
+      expect(resp.status).toBe(200);
+    }
+    await pool.close();
+  });
+
+  test('rejects after close', async () => {
+    const pool = new H2Pool(`https://localhost:${server.port}`, { tlsOptions: testTls });
+    await pool.close();
+    await expect(pool.request('/info', 'GET', {}, null)).rejects.toThrow('closed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createH2Fetch (public API)
+// ---------------------------------------------------------------------------
+
+describe('createH2Fetch', () => {
+  let server: { port: number; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    server = await startTestServer(jsonHandler);
+  });
+
+  afterAll(async () => { await server.close(); });
+
+  test('GET request returns JSON', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/info`, {
+      method: 'GET',
+      headers: {},
+    })) as any;
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.path).toBe('/info');
+  });
+
+  test('POST request sends body', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/echo`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"sent":true}',
+    })) as any;
+    const body = await resp.json();
+    expect(body.echoed).toBe('{"sent":true}');
+  });
+
+  test('response headers are accessible', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/info`, {
+      method: 'GET',
+      headers: {},
+    })) as any;
+    expect(resp.headers.get('content-type')).toBe('application/json');
+    expect(resp.headers.get('x-custom')).toBe('test-value');
+  });
+
+  test('SSE streaming via getReader', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/sse`, {
+      method: 'GET',
+      headers: { accept: 'text/event-stream' },
+    })) as any;
+    expect(resp.headers.get('content-type')).toBe('text/event-stream');
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    reader.releaseLock();
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    const combined = chunks.join('');
+    expect(combined).toContain('"id":1');
+    expect(combined).toContain('"id":2');
+  });
+
+  test('SSE streaming via async iteration', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/sse`, {
+      method: 'GET',
+      headers: { accept: 'text/event-stream' },
+    })) as any;
+
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    for await (const chunk of resp.body) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    const combined = chunks.join('');
+    expect(combined).toContain('"id":1');
+    expect(combined).toContain('"id":2');
+  });
+
+  test('strips agent from init (node-fetch compat)', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    // The SDK injects `agent` for node-fetch; h2Fetch should ignore it without error
+    const resp = (await h2Fetch(`https://localhost:${server.port}/info`, {
+      method: 'GET',
+      headers: {},
+      agent: 'should-be-ignored',
+    } as any)) as any;
+    expect(resp.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeBody (via index.ts)
+// ---------------------------------------------------------------------------
+
+describe('normalizeBody', () => {
+  let server: { port: number; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    server = await startTestServer(jsonHandler);
+  });
+
+  afterAll(async () => { await server.close(); });
+
+  test('null body (GET request)', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/info`, {
+      method: 'GET',
+      headers: {},
+    })) as any;
+    expect(resp.status).toBe(200);
+  });
+
+  test('string body', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/echo`, {
+      method: 'POST',
+      headers: {},
+      body: 'plain text',
+    })) as any;
+    const body = await resp.json();
+    expect(body.echoed).toBe('plain text');
+  });
+
+  test('Buffer body', async () => {
+    const h2Fetch = createH2Fetch({ tlsOptions: testTls });
+    const resp = (await h2Fetch(`https://localhost:${server.port}/echo`, {
+      method: 'POST',
+      headers: {},
+      body: Buffer.from('buffer data'),
+    })) as any;
+    const body = await resp.json();
+    expect(body.echoed).toBe('buffer data');
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

- Custom HTTP/2 transport built on `node:http2` for high-throughput multiplexed connections
- Connection pool with least-loaded session routing, automatic growth, and request queuing
- `createH2Fetch()` provides a fetch-compatible API surface for drop-in SDK integration
- Node 18+ version guard (requires `node:stream/web` for `ReadableStream`)
- 29 unit tests covering H2Headers, H2Response, H2Session, H2Pool, and createH2Fetch
- SSE streaming integration test with local H2 server

### Components

| File | Purpose |
|------|---------|
| `headers.ts` | Minimal `Headers` impl — strips pseudo-headers, case-insensitive lookup |
| `response.ts` | `Response` wrapper with `.json()`, `.text()`, streaming `.body` |
| `session.ts` | Single H2 connection — stream lifecycle, GOAWAY handling, abort signals |
| `pool.ts` | Connection pool — least-loaded routing, queue draining, auto-scaling |
| `index.ts` | Public API — `createH2Fetch()`, body normalization, Node version check |

## Test plan

- [x] 29 unit tests pass (`npx jest tests/lib/h2-transport.test.ts`)
- [x] SSE streaming test passes (`cd loadtest && npx tsx sse-test.ts`)
- [ ] Full SDK test suite still passes (no SDK integration changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add a standalone HTTP/2 fetch transport with streaming support and safer connection handling**

### What Changed
- Added a fetch-compatible HTTP/2 transport for Node.js that reuses persistent connections per origin and can return JSON, text, binary, and streamed responses
- Streaming responses now work with server-sent events and can be read through the response body stream
- Requests now support common body types like strings, buffers, typed arrays, and plain bodies, while unsupported streaming uploads fail with a clear error
- The transport now ignores SDK-injected `agent` settings and checks for Node.js 18+ before starting
- Added coverage for headers, responses, session lifecycle, pooling behavior, SSE streaming, and public fetch behavior

### Impact
`✅ Faster API calls over reused HTTP/2 connections`
`✅ Reliable SSE streaming from SDK requests`
`✅ Clearer errors for unsupported upload bodies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
