### PR TITLE
perf: increase undici HTTP/2 pool from 4x64 to 20x128 streams

### DIFF
--- a/src/lib/undici-fetch.ts
+++ b/src/lib/undici-fetch.ts
@@ -37,10 +37,12 @@ import { MultipartBody } from '../_shims/MultipartBody';
 import { type Fetch } from '../core';
 
 const KEEP_ALIVE_TIMEOUT_MS = 10 * 60 * 1000;
-// Bound the pool to a few TLS sessions per origin and multiplex many H2 streams
-// over each. 4 x 64 = 256 concurrent requests in flight before undici queues the rest.
-const H2_MAX_CONNECTIONS = 4;
-const H2_MAX_CONCURRENT_STREAMS = 64;
+// Bound the pool to several TLS sessions per origin and multiplex H2 streams over
+// each. The server typically advertises MAX_CONCURRENT_STREAMS=100-128; we use 128
+// per connection to match. 20 x 128 = 2560 concurrent requests in flight before
+// undici queues the rest.
+const H2_MAX_CONNECTIONS = 20;
+const H2_MAX_CONCURRENT_STREAMS = 128;
 
 // One module-scoped default dispatcher, reused across requests: a bounded HTTP/2 pool
 // with keep-alive. `allowH2` negotiates h2 over TLS via ALPN and transparently falls


### PR DESCRIPTION
## NOTE

This PR is somewhat unnecessary since I am planning to remove undici in a follow-up PR.  Nonetheless, since these tunings made a significant improvement I would rather land this before removing so we at least have the tuning in git history in case we want to revisit undici in the future.  :)

## Summary

- Raise undici pool connections from 4 to 20 and per-connection stream limit from 64 to 128
- Increases max in-flight requests from 256 to 2560 before queuing
- 128 streams/connection matches typical server `MAX_CONCURRENT_STREAMS` (100-128)

Independent of the h2-transport PRs — this improves the existing undici path.

## Test plan

- [ ] Full SDK test suite passes
- [ ] Load test with `USE_HTTP2=1` shows improved throughput under high concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Increase HTTP/2 request capacity before queuing**

### What Changed
- Raised the default HTTP/2 pool so more requests can stay in flight before new ones wait
- Increased the number of connections and streams per connection to handle heavier concurrent traffic
- Aligns the per-connection stream limit with common server settings

### Impact
`✅ Fewer request delays under heavy load`
`✅ Higher concurrency for HTTP/2 traffic`
`✅ Smoother bulk request handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
