### PR TITLE
fix: remove deprecated create_from_inspection endpoint

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
-configured_endpoints: 120
+configured_endpoints: 119
 openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/runloop-ai/runloop-8f05915b107d49f4a50f2d83abfa1d7233a685f1d85e02465a218fa5acb55ddd.yml
 openapi_spec_hash: 905fa27970b4b7201184df9c63eba3b9
 config_hash: ed1fdd7c9f0a25647e16b602bad4ff2e

--- a/api.md
+++ b/api.md
@@ -146,14 +146,12 @@ Methods:
 
 Types:
 
-- <code><a href="./src/resources/blueprints.ts">BlueprintBuildFromInspectionParameters</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintBuildLog</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintBuildLogsListView</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintBuildParameters</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintListView</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintPreviewView</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintView</a></code>
-- <code><a href="./src/resources/blueprints.ts">InspectionSource</a></code>
 - <code><a href="./src/resources/blueprints.ts">BlueprintDeleteResponse</a></code>
 
 Methods:
@@ -162,7 +160,6 @@ Methods:
 - <code title="get /v1/blueprints/{id}">client.blueprints.<a href="./src/resources/blueprints.ts">retrieve</a>(id) -> BlueprintView</code>
 - <code title="get /v1/blueprints">client.blueprints.<a href="./src/resources/blueprints.ts">list</a>({ ...params }) -> BlueprintViewsBlueprintsCursorIDPage</code>
 - <code title="post /v1/blueprints/{id}/delete">client.blueprints.<a href="./src/resources/blueprints.ts">delete</a>(id) -> unknown</code>
-- <code title="post /v1/blueprints/create_from_inspection">client.blueprints.<a href="./src/resources/blueprints.ts">createFromInspection</a>({ ...params }) -> BlueprintView</code>
 - <code title="get /v1/blueprints/list_public">client.blueprints.<a href="./src/resources/blueprints.ts">listPublic</a>({ ...params }) -> BlueprintViewsBlueprintsCursorIDPage</code>
 - <code title="get /v1/blueprints/{id}/logs">client.blueprints.<a href="./src/resources/blueprints.ts">logs</a>(id) -> BlueprintBuildLogsListView</code>
 - <code title="post /v1/blueprints/preview">client.blueprints.<a href="./src/resources/blueprints.ts">preview</a>({ ...params }) -> BlueprintPreviewView</code>

--- a/packages/mcp-server/src/code-tool-worker.ts
+++ b/packages/mcp-server/src/code-tool-worker.ts
@@ -124,7 +124,6 @@ const fuse = new Fuse(
     'client.agents.list',
     'client.agents.retrieve',
     'client.blueprints.create',
-    'client.blueprints.createFromInspection',
     'client.blueprints.delete',
     'client.blueprints.list',
     'client.blueprints.listPublic',

--- a/packages/mcp-server/src/methods.ts
+++ b/packages/mcp-server/src/methods.ts
@@ -149,12 +149,6 @@ export const sdkMethods: SdkMethod[] = [
     httpPath: '/v1/blueprints/{id}/delete',
   },
   {
-    clientCallName: 'client.blueprints.createFromInspection',
-    fullyQualifiedName: 'blueprints.createFromInspection',
-    httpMethod: 'post',
-    httpPath: '/v1/blueprints/create_from_inspection',
-  },
-  {
     clientCallName: 'client.blueprints.listPublic',
     fullyQualifiedName: 'blueprints.listPublic',
     httpMethod: 'get',

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,11 +84,9 @@ import {
   StartBenchmarkRunParameters,
 } from './resources/benchmarks';
 import {
-  BlueprintBuildFromInspectionParameters,
   BlueprintBuildLog,
   BlueprintBuildLogsListView,
   BlueprintBuildParameters,
-  BlueprintCreateFromInspectionParams,
   BlueprintCreateParams,
   BlueprintDeleteResponse,
   BlueprintListParams,
@@ -99,7 +97,6 @@ import {
   BlueprintView,
   BlueprintViewsBlueprintsCursorIDPage,
   Blueprints,
-  InspectionSource,
 } from './resources/blueprints';
 import {
   GatewayConfigCreateParameters,
@@ -668,19 +665,16 @@ export declare namespace Runloop {
 
   export {
     Blueprints as Blueprints,
-    type BlueprintBuildFromInspectionParameters as BlueprintBuildFromInspectionParameters,
     type BlueprintBuildLog as BlueprintBuildLog,
     type BlueprintBuildLogsListView as BlueprintBuildLogsListView,
     type BlueprintBuildParameters as BlueprintBuildParameters,
     type BlueprintListView as BlueprintListView,
     type BlueprintPreviewView as BlueprintPreviewView,
     type BlueprintView as BlueprintView,
-    type InspectionSource as InspectionSource,
     type BlueprintDeleteResponse as BlueprintDeleteResponse,
     BlueprintViewsBlueprintsCursorIDPage as BlueprintViewsBlueprintsCursorIDPage,
     type BlueprintCreateParams as BlueprintCreateParams,
     type BlueprintListParams as BlueprintListParams,
-    type BlueprintCreateFromInspectionParams as BlueprintCreateFromInspectionParams,
     type BlueprintListPublicParams as BlueprintListPublicParams,
     type BlueprintPreviewParams as BlueprintPreviewParams,
   };

--- a/src/resources/blueprints.ts
+++ b/src/resources/blueprints.ts
@@ -170,21 +170,6 @@ export class Blueprints extends APIResource {
   }
 
   /**
-   * Starts build of custom defined container Blueprint using a RepositoryConnection
-   * Inspection as a source container specification.
-   */
-  createFromInspection(
-    body: BlueprintCreateFromInspectionParams,
-    options?: Core.RequestOptions,
-  ): Core.APIPromise<BlueprintView> {
-    const errors = validateFileMounts(body?.file_mounts);
-    if (errors.length > 0) {
-      throw new Error(errors.join('; '));
-    }
-    return this._client.post('/v1/blueprints/create_from_inspection', { body, ...options });
-  }
-
-  /**
    * List all public Blueprints that are available to all users.
    */
   listPublic(
@@ -229,55 +214,6 @@ export class Blueprints extends APIResource {
 }
 
 export class BlueprintViewsBlueprintsCursorIDPage extends BlueprintsCursorIDPage<BlueprintView> {}
-
-export interface BlueprintBuildFromInspectionParameters {
-  /**
-   * (Optional) Use a RepositoryInspection a source of a Blueprint build. The
-   * Dockerfile will be automatically created based on the RepositoryInspection
-   * contents.
-   */
-  inspection_source: InspectionSource;
-
-  /**
-   * Name of the Blueprint.
-   */
-  name: string;
-
-  /**
-   * (Optional) Map of paths and file contents to write before setup.
-   */
-  file_mounts?: { [key: string]: string } | null;
-
-  /**
-   * LaunchParameters enable you to customize the resources available to your Devbox
-   * as well as the environment set up that should be completed before the Devbox is
-   * marked as 'running'.
-   */
-  launch_parameters?: Shared.LaunchParameters | null;
-
-  /**
-   * (Optional) User defined metadata for the Blueprint.
-   */
-  metadata?: { [key: string]: string } | null;
-
-  /**
-   * (Optional) ID of the network policy to apply during blueprint build. This
-   * restricts network access during the build process.
-   */
-  network_policy_id?: string | null;
-
-  /**
-   * (Optional) Map of mount IDs/environment variable names to secret names. Secrets
-   * can be used as environment variables in system_setup_commands. Example:
-   * {"GITHUB_TOKEN": "gh_secret"} makes 'gh_secret' available as GITHUB_TOKEN.
-   */
-  secrets?: { [key: string]: string } | null;
-
-  /**
-   * A list of commands to run to set up your system.
-   */
-  system_setup_commands?: Array<string> | null;
-}
 
 export interface BlueprintBuildLog {
   /**
@@ -609,21 +545,6 @@ export namespace BlueprintView {
   }
 }
 
-/**
- * Use a RepositoryInspection a source of a Blueprint build.
- */
-export interface InspectionSource {
-  /**
-   * The ID of a repository inspection.
-   */
-  inspection_id: string;
-
-  /**
-   * GitHub authentication token for accessing private repositories.
-   */
-  github_auth_token?: string | null;
-}
-
 export type BlueprintDeleteResponse = unknown;
 
 /**
@@ -800,55 +721,6 @@ export interface BlueprintListParams extends BlueprintsCursorIDPageParams {
   status?: string;
 }
 
-export interface BlueprintCreateFromInspectionParams {
-  /**
-   * (Optional) Use a RepositoryInspection a source of a Blueprint build. The
-   * Dockerfile will be automatically created based on the RepositoryInspection
-   * contents.
-   */
-  inspection_source: InspectionSource;
-
-  /**
-   * Name of the Blueprint.
-   */
-  name: string;
-
-  /**
-   * (Optional) Map of paths and file contents to write before setup.
-   */
-  file_mounts?: { [key: string]: string } | null;
-
-  /**
-   * LaunchParameters enable you to customize the resources available to your Devbox
-   * as well as the environment set up that should be completed before the Devbox is
-   * marked as 'running'.
-   */
-  launch_parameters?: Shared.LaunchParameters | null;
-
-  /**
-   * (Optional) User defined metadata for the Blueprint.
-   */
-  metadata?: { [key: string]: string } | null;
-
-  /**
-   * (Optional) ID of the network policy to apply during blueprint build. This
-   * restricts network access during the build process.
-   */
-  network_policy_id?: string | null;
-
-  /**
-   * (Optional) Map of mount IDs/environment variable names to secret names. Secrets
-   * can be used as environment variables in system_setup_commands. Example:
-   * {"GITHUB_TOKEN": "gh_secret"} makes 'gh_secret' available as GITHUB_TOKEN.
-   */
-  secrets?: { [key: string]: string } | null;
-
-  /**
-   * A list of commands to run to set up your system.
-   */
-  system_setup_commands?: Array<string> | null;
-}
-
 export interface BlueprintListPublicParams extends BlueprintsCursorIDPageParams {
   /**
    * If true (default), includes total_count in the response. Set to false to skip
@@ -1022,19 +894,16 @@ Blueprints.BlueprintViewsBlueprintsCursorIDPage = BlueprintViewsBlueprintsCursor
 
 export declare namespace Blueprints {
   export {
-    type BlueprintBuildFromInspectionParameters as BlueprintBuildFromInspectionParameters,
     type BlueprintBuildLog as BlueprintBuildLog,
     type BlueprintBuildLogsListView as BlueprintBuildLogsListView,
     type BlueprintBuildParameters as BlueprintBuildParameters,
     type BlueprintListView as BlueprintListView,
     type BlueprintPreviewView as BlueprintPreviewView,
     type BlueprintView as BlueprintView,
-    type InspectionSource as InspectionSource,
     type BlueprintDeleteResponse as BlueprintDeleteResponse,
     BlueprintViewsBlueprintsCursorIDPage as BlueprintViewsBlueprintsCursorIDPage,
     type BlueprintCreateParams as BlueprintCreateParams,
     type BlueprintListParams as BlueprintListParams,
-    type BlueprintCreateFromInspectionParams as BlueprintCreateFromInspectionParams,
     type BlueprintListPublicParams as BlueprintListPublicParams,
     type BlueprintPreviewParams as BlueprintPreviewParams,
   };

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -69,18 +69,15 @@ export {
 export {
   BlueprintViewsBlueprintsCursorIDPage,
   Blueprints,
-  type BlueprintBuildFromInspectionParameters,
   type BlueprintBuildLog,
   type BlueprintBuildLogsListView,
   type BlueprintBuildParameters,
   type BlueprintListView,
   type BlueprintPreviewView,
   type BlueprintView,
-  type InspectionSource,
   type BlueprintDeleteResponse,
   type BlueprintCreateParams,
   type BlueprintListParams,
-  type BlueprintCreateFromInspectionParams,
   type BlueprintListPublicParams,
   type BlueprintPreviewParams,
 } from './blueprints';

--- a/tests/api-resources/blueprints.test.ts
+++ b/tests/api-resources/blueprints.test.ts
@@ -170,52 +170,6 @@ describe('resource blueprints', () => {
     );
   });
 
-  test('createFromInspection: only required params', async () => {
-    const responsePromise = client.blueprints.createFromInspection({
-      inspection_source: { inspection_id: 'inspection_id' },
-      name: 'name',
-    });
-    const rawResponse = await responsePromise.asResponse();
-    expect(rawResponse).toBeInstanceOf(Response);
-    const response = await responsePromise;
-    expect(response).not.toBeInstanceOf(Response);
-    const dataAndResponse = await responsePromise.withResponse();
-    expect(dataAndResponse.data).toBe(response);
-    expect(dataAndResponse.response).toBe(rawResponse);
-  });
-
-  test('createFromInspection: required and optional params', async () => {
-    const response = await client.blueprints.createFromInspection({
-      inspection_source: { inspection_id: 'inspection_id', github_auth_token: 'github_auth_token' },
-      name: 'name',
-      file_mounts: { foo: 'string' },
-      launch_parameters: {
-        after_idle: { idle_time_seconds: 0, on_idle: 'shutdown' },
-        architecture: 'x86_64',
-        available_ports: [0],
-        custom_cpu_cores: 0,
-        custom_disk_size: 0,
-        custom_gb_memory: 0,
-        keep_alive_time_seconds: 0,
-        launch_commands: ['string'],
-        lifecycle: {
-          after_idle: { idle_time_seconds: 0, on_idle: 'shutdown' },
-          lifecycle_hooks: { suspend_commands: ['string'], suspend_deadline_ms: 0 },
-          resume_triggers: { axon_event: true, http: true },
-        },
-        network_policy_id: 'network_policy_id',
-        provisioning_tier: 'standard',
-        required_services: ['string'],
-        resource_size_request: 'X_SMALL',
-        user_parameters: { uid: 0, username: 'username' },
-      },
-      metadata: { foo: 'string' },
-      network_policy_id: 'network_policy_id',
-      secrets: { foo: 'string' },
-      system_setup_commands: ['string'],
-    });
-  });
-
   test('listPublic', async () => {
     const responsePromise = client.blueprints.listPublic();
     const rawResponse = await responsePromise.asResponse();


### PR DESCRIPTION
## **User description**
## Summary

- Remove the broken `createFromInspection` blueprint endpoint (`POST /v1/blueprints/create_from_inspection`) and all associated types (`BlueprintBuildFromInspectionParameters`, `InspectionSource`, `BlueprintCreateFromInspectionParams`)
- These were part of the retired RepoConnect project; the upstream API already removed this route
- Also removes the MCP server tooling entry and tests referencing this endpoint

## Test plan

- [x] TypeScript type-check passes (only pre-existing `undici` error remains, unrelated)
- [x] Grep confirms zero remaining references to the removed endpoint/types
- [x] `.stats.yml` endpoint count decremented to 119

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Remove the broken blueprint creation-from-inspection call**

### What Changed
- Removed the `create from inspection` blueprint action from the client and MCP tool list, so it is no longer offered as an available blueprint method
- Removed the related type references from the public API docs and exports
- Removed the test coverage that called the retired endpoint

### Impact
`✅ Fewer calls to a retired blueprint endpoint`
`✅ Clearer API surface for blueprint actions`
`✅ Less confusion when browsing available MCP tools`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
