### PR TITLE
fix(smoketests): instrument node:http2 in verify-http2.mjs, not undici

### DIFF
--- a/tests/smoketests/scripts/verify-http2.mjs
+++ b/tests/smoketests/scripts/verify-http2.mjs
@@ -1,12 +1,12 @@
 /**
- * Plain-node verification harness for the HTTP/2 (undici) transport.
+ * Plain-node verification harness for the HTTP/2 (node:http2) transport.
  *
  * Runs OUTSIDE jest against the BUILT package — which is exactly how real
  * clients consume the SDK, and the only place a `"type": "commonjs"` interop
  * regression would surface. It proves three things a green smoke run cannot:
  *
- *   1. h2 is actually NEGOTIATED (not a silent HTTP/1.1 fallback) — asserted by
- *      reading the TLS socket's ALPN protocol via undici's diagnostics channel.
+ *   1. h2 is actually NEGOTIATED — asserted by reading the TLS socket's ALPN
+ *      protocol on every `http2.connect` session the SDK opens.
  *   2. A success response body parses (exercises Response.json()).
  *   3. A non-2xx response REJECTS with a readable error and does NOT crash the
  *      process — the exact failure mode of the old got adapter on a 401.
@@ -14,8 +14,25 @@
  * Usage: RUNLOOP_API_KEY=... [RUNLOOP_BASE_URL=...] node tests/smoketests/scripts/verify-http2.mjs
  * Exit code 0 = all checks passed, 1 = a check failed, 2 = misconfigured.
  */
-import diagnostics_channel from 'node:diagnostics_channel';
+import http2 from 'node:http2';
 import { createRequire } from 'node:module';
+
+// Capture the negotiated ALPN protocol for every H2 session the transport opens.
+// `node:http2` is a singleton module shared between this ESM harness and the CJS
+// dist bundle, so wrapping `connect` here instruments the SDK's own sessions.
+// Must be installed BEFORE the SDK is required.
+const alpnSeen = [];
+let connectCount = 0;
+const realConnect = http2.connect;
+http2.connect = function (...args) {
+  connectCount++;
+  const session = realConnect.apply(this, args);
+  session.on('connect', () => {
+    const proto = session.socket?.alpnProtocol;
+    if (proto) alpnSeen.push(proto);
+  });
+  return session;
+};
 
 const require = createRequire(import.meta.url);
 const distPath = new URL('../../../dist/index.js', import.meta.url).pathname;
@@ -27,17 +44,6 @@ if (!apiKey) {
   console.error('RUNLOOP_API_KEY is required');
   process.exit(2);
 }
-
-// Capture the negotiated ALPN protocol for every undici connection. Channels are
-// keyed by name globally, so this catches the SDK's own undici regardless of
-// which module instance created the connection.
-const alpnSeen = [];
-let connectCount = 0;
-diagnostics_channel.subscribe('undici:client:connected', (msg) => {
-  connectCount++;
-  const proto = msg?.socket?.alpnProtocol;
-  if (proto) alpnSeen.push(proto);
-});
 
 let failures = 0;
 const check = (cond, label) => {
@@ -80,8 +86,9 @@ try {
 
 // ── Pass D: HTTP/2 multiplexing — many concurrent requests reuse few connections ──
 // The whole point of the bounded H2 pool: N concurrent requests share a small number of
-// TLS sessions instead of one connection per request. Default config (pipelining=1) or the
-// pre-fix undici Agent would open ~N connections here.
+// TLS sessions instead of one connection per request. The pool eagerly opens
+// minConnections (4) sessions and only scales beyond that under stream saturation,
+// so a fresh client serving 25 concurrent requests should open exactly 4.
 try {
   const N = 25;
   const before = connectCount;


### PR DESCRIPTION
## **User description**
## Summary

The dev smoketest job `test-sdk / smoke-tests (http2)` (dispatched from `runloopai/runloop` deploys) has been failing deterministically with:

```
FAIL: h2: TLS ALPN negotiated 'h2' (saw: none)
```

The environment is healthy — `api.runloop.pro` negotiates `h2` via ALPN (verified with `openssl s_client` and `curl --http2`). The harness is what broke: `verify-http2.mjs` detects ALPN by subscribing to undici's `undici:client:connected` diagnostics channel, but since **1.24.0** (#799, #800) the `http2: true` transport is built on `node:http2`. Undici is never involved, so:

- the ALPN check always sees `none` and fails, and
- the Pass-D "connections opened" counter always reads 0, making the multiplexing check pass vacuously.

The harness last ran green against dev on 2026-06-10 — before 1.24.0 shipped.

## Fix

Wrap `http2.connect` (a singleton core module shared with the CJS dist bundle) before requiring the SDK, and record `session.socket.alpnProtocol` on each session's `connect` event. The same wrapper's call count now drives the Pass-D connection assertion, restoring its teeth: the pool eagerly opens `minConnections` (4) sessions, so 25 concurrent requests on a fresh client open exactly 4.

## Test plan

- [x] Built the package and ran the harness against `https://api.runloop.pro` with a deliberately invalid key (no dev key available locally):
  - `PASS: h2: TLS ALPN negotiated 'h2' (saw: h2, h2, h2, h2)` (previously `saw: none`)
  - `PASS: h2: 25 concurrent requests multiplexed over <= 4 connections (opened 4)` (previously `opened 0`)
  - `PASS` on both Pass-B error-path checks (401 rejects cleanly with readable body)
  - The only failing checks were the three that require a valid `RUNLOOP_API_KEY`; CI injects `DEV_KEY` and should go fully green.
- [ ] `smoke-tests (http2)` green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix the HTTP/2 smoke test so it checks the real transport again**

### What Changed
- The HTTP/2 verification script now watches the SDK’s actual `node:http2` connections instead of an unrelated undici signal
- It records the negotiated TLS protocol for each HTTP/2 session and uses that to confirm h2 is really in use
- The concurrent request check now counts real HTTP/2 sessions again, so it can catch cases where too many connections are opened
- The script comments and expectations were updated to match the current HTTP/2 transport behavior

### Impact
`✅ Reliable HTTP/2 smoke tests`
`✅ Fewer false test failures`
`✅ Stronger multiplexing checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
