### PR TITLE
feat: default to HTTP/2 transport on Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,29 +357,27 @@ await runloop.devboxes.create({...}, {
 
 ### HTTP/2 transport
 
-On Node.js, the SDK can send requests over HTTP/2, which multiplexes many concurrent requests over a small number of TLS connections instead of opening a connection per request. Enable it with the `http2` option:
+On Node.js, the SDK sends requests over HTTP/2 **by default**, multiplexing many concurrent requests over a small number of TLS connections instead of opening a connection per request. The transport is built on Node's native `node:http2` and manages a bounded pool of persistent H2 sessions per origin, auto-scaling with load. On the web, Deno, and other runtimes the platform `fetch` already speaks HTTP/2, so this option is a no-op there.
+
+To tune the pool — for example to raise the number of connections for a high-concurrency workload — pass options as `http2`:
 
 <!-- prettier-ignore -->
 ```ts
 const runloop = new RunloopSDK({
-  http2: true,
+  http2: { maxConnections: 20 },
 });
 ```
 
-Requests are routed through an [undici](https://github.com/nodejs/undici) connection pool with HTTP/2 enabled, falling back to HTTP/1.1 for origins that don't negotiate h2 via ALPN. It is intended for HTTP/2-capable origins such as the Runloop API. This transport uses undici and therefore **requires Node.js >= 20.18.1** (see Requirements).
-
-`http2: true` uses a default bounded pool. To control the pool yourself — for example to raise the number of connections or multiplexed streams for a high-concurrency workload — pass a configured undici `Dispatcher` (such as an `Agent`) instead. The SDK uses it verbatim and does not manage its lifecycle, the same way it treats a custom `httpAgent`:
+To opt out and use the HTTP/1.1 `node-fetch` transport, set `http2: false`:
 
 <!-- prettier-ignore -->
 ```ts
-import { Agent } from 'undici';
-
 const runloop = new RunloopSDK({
-  http2: new Agent({ allowH2: true, connections: 8, pipelining: 100 }),
+  http2: false,
 });
 ```
 
-The `httpAgent` option does not apply to the HTTP/2 transport (undici has no Node `http.Agent` concept); set `http2` to a `Dispatcher` to tune connections. A one-time warning is emitted if both `http2` and `httpAgent` are provided.
+The `httpAgent` option only applies to the HTTP/1.1 transport — the H2 pool manages its own connections. Passing an `httpAgent` without an explicit `http2` value keeps the client on HTTP/1.1 (with a one-time warning); pass `http2: false` to select HTTP/1.1 explicitly and silence the warning. A custom `fetch` always takes precedence over `http2`.
 
 ## Semantic versioning
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ TypeScript >= 4.5 is supported.
 The following runtimes are supported:
 
 - Web browsers (Up-to-date Chrome, Firefox, Safari, Edge, and more)
-- Node.js 20.18.1 LTS or later ([non-EOL](https://endoflife.date/nodejs)) versions. (Raised from 18 because the SDK now depends on undici 7 on Node; the HTTP/2 transport needs the undici >= 7.23.0 crash fix, and the package pins `^7.26.0`.)
+- Node.js 20.18.1 LTS or later ([non-EOL](https://endoflife.date/nodejs)) versions.
 - Deno v1.28.0 or higher.
 - Bun 1.0 or later.
 - Cloudflare Workers.

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ const runloop = new RunloopSDK({
 });
 ```
 
-The `httpAgent` option only applies to the HTTP/1.1 transport — the H2 pool manages its own connections. Passing an `httpAgent` without an explicit `http2` value keeps the client on HTTP/1.1 (with a one-time warning); pass `http2: false` to select HTTP/1.1 explicitly and silence the warning. A custom `fetch` always takes precedence over `http2`.
+The `httpAgent` option only applies to the HTTP/1.1 transport. A Node `http.Agent` configures HTTP/1.1 socket pooling (keep-alive, max sockets), which has no equivalent under HTTP/2 — the H2 transport multiplexes over its own managed connections — so `httpAgent` has no effect there. To tune HTTP/2 connection behavior, use `http2: { … }` instead. To keep an existing `httpAgent` working, passing one without an explicit `http2` value keeps the client on HTTP/1.1 (with a one-time warning); pass `http2: false` to select HTTP/1.1 explicitly and silence the warning. If both `httpAgent` and `http2` are set, `httpAgent` is ignored (also warned once). A custom `fetch` always takes precedence over `http2`.
 
 ## Semantic versioning
 

--- a/src/_shims/index-deno.ts
+++ b/src/_shims/index-deno.ts
@@ -10,8 +10,8 @@ type _fetch = typeof fetch;
 export { _fetch as fetch };
 
 // The platform `fetch` already negotiates HTTP/2 at the transport layer, so
-// `{ http2: ... }` is a no-op on Deno — reuse the global fetch and ignore any passed
-// dispatcher (undici dispatchers are a Node-only concept).
+// `{ http2: ... }` is a no-op on Deno — reuse the global fetch and ignore any
+// passed pool options (the `node:http2` transport is Node-only).
 export const makeHttp2Fetch = () => _fetch;
 
 const _Request = Request;

--- a/src/_shims/index.d.ts
+++ b/src/_shims/index.d.ts
@@ -17,12 +17,12 @@ export const fetch: SelectType<typeof manual.fetch, typeof auto.fetch>;
 
 /**
  * Build an HTTP/2-capable `fetch`, used when the client is constructed with
- * `{ http2: ... }`. In Node this is the undici adapter (`Agent({ allowH2: true })`);
- * the optional `dispatcher` lets the caller pass a configured undici `Dispatcher`
- * (the `http2: <Dispatcher>` passthrough), defaulting to the SDK's bounded pool. On
- * the web it returns the platform `fetch`, which already negotiates HTTP/2.
+ * `{ http2: ... }`. On Node this is the native `node:http2` transport; the
+ * optional `options` tune its connection pool (the `http2: <H2FetchOptions>`
+ * passthrough), defaulting to the SDK's shared bounded pool. On the web it
+ * returns the platform `fetch`, which already negotiates HTTP/2.
  */
-export function makeHttp2Fetch(dispatcher?: any): typeof fetch;
+export function makeHttp2Fetch(options?: any): typeof fetch;
 
 // @ts-ignore
 export type Request = SelectType<manual.Request, auto.Request>;

--- a/src/_shims/registry.ts
+++ b/src/_shims/registry.ts
@@ -8,12 +8,12 @@ export interface Shims {
   fetch: any;
   /**
    * Build an HTTP/2-capable `fetch`, used when the client is constructed with
-   * `{ http2: ... }`. In Node this is the undici adapter (`Agent({ allowH2: true })`);
-   * the optional `dispatcher` lets the caller pass a configured undici `Dispatcher`
-   * (the `http2: <Dispatcher>` passthrough), defaulting to the SDK's bounded pool. On
-   * the web the platform `fetch` already negotiates HTTP/2, so the argument is ignored.
+   * `{ http2: ... }`. On Node this is the native `node:http2` transport; the
+   * optional `options` tune its connection pool (the `http2: <H2FetchOptions>`
+   * passthrough), defaulting to the SDK's shared bounded pool. On the web the
+   * platform `fetch` already negotiates HTTP/2, so the argument is ignored.
    */
-  makeHttp2Fetch: (dispatcher?: any) => any;
+  makeHttp2Fetch: (options?: any) => any;
   Request: any;
   Response: any;
   Headers: any;

--- a/src/_shims/web-runtime.ts
+++ b/src/_shims/web-runtime.ts
@@ -36,8 +36,8 @@ export function getRuntime({ manuallyImported }: { manuallyImported?: boolean } 
     kind: 'web',
     fetch: _fetch,
     // The platform `fetch` already negotiates HTTP/2 at the transport layer, so
-    // `{ http2: ... }` is a no-op on the web — reuse the global fetch and ignore any
-    // passed dispatcher (undici dispatchers are a Node-only concept).
+    // `{ http2: ... }` is a no-op on the web — reuse the global fetch and ignore
+    // any passed pool options (the `node:http2` transport is Node-only).
     makeHttp2Fetch: () => _fetch,
     Request: _Request,
     Response: _Response,

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,7 +361,7 @@ export class Runloop extends Core.APIClient {
    * @param {number} [opts.timeout=30 seconds] - The maximum amount of time (in milliseconds) the client will wait for a response before timing out.
    * @param {number} [opts.httpAgent] - An HTTP agent used to manage HTTP(s) connections.
    * @param {Core.Fetch} [opts.fetch] - Specify a custom `fetch` function implementation.
-   * @param {boolean | H2FetchOptions} [opts.http2=true] - Send requests over HTTP/2 (Node only; ignored when `fetch` is provided). Enabled by default; pass `false` to use HTTP/1.1, or H2FetchOptions to tune the pool.
+   * @param {boolean | H2FetchOptions} [opts.http2=true] - Send requests over HTTP/2. Enabled by default on Node.js; pass `false` to use HTTP/1.1, or H2FetchOptions to tune the pool. Has no effect on browsers/Deno/Bun (their platform `fetch` already uses HTTP/2) or when a custom `fetch` is provided.
    * @param {number} [opts.maxRetries=5] - The maximum number of times the client will retry a request.
    * @param {Core.Headers} opts.defaultHeaders - Default headers to include with every request to the API.
    * @param {Core.DefaultQuery} opts.defaultQuery - Default query parameters to include with every request to the API.

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,14 +294,20 @@ export interface ClientOptions {
   /**
    * Send requests over HTTP/2 using native `node:http2` connection pools.
    *
-   * - `true` uses the SDK's default bounded HTTP/2 pool.
+   * HTTP/2 is the default transport on Node.js: it multiplexes many concurrent
+   * requests over a small number of TLS connections instead of opening one
+   * connection per request.
+   *
+   * - `true` / omitted uses the SDK's default bounded HTTP/2 pool.
    * - Pass `H2FetchOptions` to tune pool size, timeouts, etc.
+   * - `false` opts out and uses the HTTP/1.1 `node-fetch` transport.
    *
    * On the HTTP/2 path the `httpAgent` option is not used — the H2 transport
-   * manages its own persistent connections. A one-time warning is emitted if
-   * both `http2` and `httpAgent` are set.
+   * manages its own persistent connections. Passing an `httpAgent` without an
+   * explicit `http2` value keeps the client on HTTP/1.1 (with a one-time
+   * warning); pass `http2: false` to opt out silently.
    *
-   * @default false
+   * @default true
    */
   http2?: boolean | import('./lib/h2-transport').H2FetchOptions | undefined;
 
@@ -341,10 +347,15 @@ export interface ClientOptions {
  * console.log(result.exitCode);
  * ```
  */
-// Emitted at most once per process when `http2` and `httpAgent` are combined (see
-// the constructor). Module-scoped flag mirrors the `fileFromPathWarned` pattern in
-// _shims/node-runtime.ts.
+// Emitted at most once per process each (see the constructor). Module-scoped flags
+// mirror the `fileFromPathWarned` pattern in _shims/node-runtime.ts.
+//
+// `http2HttpAgentWarned`   — user explicitly set `http2` *and* `httpAgent`; the agent
+//                            is ignored on the H2 path.
+// `http2DefaultAgentWarned`— user set `httpAgent` without an explicit `http2` value, so
+//                            the client stays on HTTP/1.1 rather than the H2 default.
 let http2HttpAgentWarned = false;
+let http2DefaultAgentWarned = false;
 
 export class Runloop extends Core.APIClient {
   bearerToken: string;
@@ -359,7 +370,7 @@ export class Runloop extends Core.APIClient {
    * @param {number} [opts.timeout=30 seconds] - The maximum amount of time (in milliseconds) the client will wait for a response before timing out.
    * @param {number} [opts.httpAgent] - An HTTP agent used to manage HTTP(s) connections.
    * @param {Core.Fetch} [opts.fetch] - Specify a custom `fetch` function implementation.
-   * @param {boolean | H2FetchOptions} [opts.http2=false] - Send requests over HTTP/2 (Node only; ignored when `fetch` is provided). `true` uses the default bounded pool; pass H2FetchOptions to tune.
+   * @param {boolean | H2FetchOptions} [opts.http2=true] - Send requests over HTTP/2 (Node only; ignored when `fetch` is provided). Enabled by default; pass `false` to use HTTP/1.1, or H2FetchOptions to tune the pool.
    * @param {number} [opts.maxRetries=5] - The maximum number of times the client will retry a request.
    * @param {Core.Headers} opts.defaultHeaders - Default headers to include with every request to the API.
    * @param {Core.DefaultQuery} opts.defaultQuery - Default query parameters to include with every request to the API.
@@ -381,15 +392,43 @@ export class Runloop extends Core.APIClient {
       baseURL: baseURL || `https://api.runloop.ai`,
     };
 
-    // `httpAgent` does not apply to the HTTP/2 transport — it manages its own
-    // persistent connections. Warn once instead of silently ignoring.
-    if (!options.fetch && options.http2 && options.httpAgent && !http2HttpAgentWarned) {
-      http2HttpAgentWarned = true;
-      console.warn(
-        '[runloop] `httpAgent` is ignored when `http2` is set: the HTTP/2 transport manages ' +
-          'its own connections. To tune the H2 pool, pass options as `http2` ' +
-          '(e.g. `http2: { maxConnections: 20 }`).',
-      );
+    // Resolve the transport. HTTP/2 is the default on Node; a user-supplied
+    // `fetch` always wins, `http2: false` opts out, and a bare `httpAgent`
+    // (no explicit `http2`) keeps the client on HTTP/1.1 so existing agents
+    // keep working. `httpAgent` never applies to the H2 path — it manages its
+    // own persistent connections.
+    let useHttp2: boolean;
+    if (options.fetch) {
+      // Custom fetch owns the transport entirely.
+      useHttp2 = false;
+    } else if (options.http2 === false) {
+      useHttp2 = false;
+    } else if (options.http2) {
+      // Explicit opt-in (`true` or H2FetchOptions).
+      useHttp2 = true;
+      if (options.httpAgent && !http2HttpAgentWarned) {
+        http2HttpAgentWarned = true;
+        console.warn(
+          '[runloop] `httpAgent` is ignored when `http2` is set: the HTTP/2 transport manages ' +
+            'its own connections. To tune the H2 pool, pass options as `http2` ' +
+            '(e.g. `http2: { maxConnections: 20 }`).',
+        );
+      }
+    } else if (options.httpAgent) {
+      // Default would be H2, but a `httpAgent` was provided — respect it and
+      // stay on HTTP/1.1, warning once so the fallback isn't silent.
+      useHttp2 = false;
+      if (!http2DefaultAgentWarned) {
+        http2DefaultAgentWarned = true;
+        console.warn(
+          '[runloop] HTTP/2 is the default transport, but `httpAgent` is set, so this client ' +
+            'uses HTTP/1.1. Remove `httpAgent` to use HTTP/2, or pass `http2: false` to select ' +
+            'HTTP/1.1 explicitly and silence this warning.',
+        );
+      }
+    } else {
+      // New default: HTTP/2.
+      useHttp2 = true;
     }
 
     super({
@@ -400,7 +439,7 @@ export class Runloop extends Core.APIClient {
       maxRetries: options.maxRetries,
       fetch:
         options.fetch ??
-        (options.http2 ?
+        (useHttp2 ?
           makeHttp2Fetch(typeof options.http2 === 'object' ? options.http2 : undefined)
         : undefined),
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import { type Agent, makeHttp2Fetch } from './_shims/index';
+import { type Agent } from './_shims/index';
+import { resolveHttp2Fetch } from './lib/http2-transport';
 import * as Core from './core';
 import * as Errors from './error';
 import * as Pagination from './pagination';
@@ -347,16 +348,6 @@ export interface ClientOptions {
  * console.log(result.exitCode);
  * ```
  */
-// Emitted at most once per process each (see the constructor). Module-scoped flags
-// mirror the `fileFromPathWarned` pattern in _shims/node-runtime.ts.
-//
-// `http2HttpAgentWarned`   — user explicitly set `http2` *and* `httpAgent`; the agent
-//                            is ignored on the H2 path.
-// `http2DefaultAgentWarned`— user set `httpAgent` without an explicit `http2` value, so
-//                            the client stays on HTTP/1.1 rather than the H2 default.
-let http2HttpAgentWarned = false;
-let http2DefaultAgentWarned = false;
-
 export class Runloop extends Core.APIClient {
   bearerToken: string;
 
@@ -392,56 +383,15 @@ export class Runloop extends Core.APIClient {
       baseURL: baseURL || `https://api.runloop.ai`,
     };
 
-    // Resolve the transport. HTTP/2 is the default on Node; a user-supplied
-    // `fetch` always wins, `http2: false` opts out, and a bare `httpAgent`
-    // (no explicit `http2`) keeps the client on HTTP/1.1 so existing agents
-    // keep working. `httpAgent` never applies to the H2 path — it manages its
-    // own persistent connections.
-    let useHttp2: boolean;
-    if (options.fetch) {
-      // Custom fetch owns the transport entirely.
-      useHttp2 = false;
-    } else if (options.http2 === false) {
-      useHttp2 = false;
-    } else if (options.http2) {
-      // Explicit opt-in (`true` or H2FetchOptions).
-      useHttp2 = true;
-      if (options.httpAgent && !http2HttpAgentWarned) {
-        http2HttpAgentWarned = true;
-        console.warn(
-          '[runloop] `httpAgent` is ignored when `http2` is set: the HTTP/2 transport manages ' +
-            'its own connections. To tune the H2 pool, pass options as `http2` ' +
-            '(e.g. `http2: { maxConnections: 20 }`).',
-        );
-      }
-    } else if (options.httpAgent) {
-      // Default would be H2, but a `httpAgent` was provided — respect it and
-      // stay on HTTP/1.1, warning once so the fallback isn't silent.
-      useHttp2 = false;
-      if (!http2DefaultAgentWarned) {
-        http2DefaultAgentWarned = true;
-        console.warn(
-          '[runloop] HTTP/2 is the default transport, but `httpAgent` is set, so this client ' +
-            'uses HTTP/1.1. Remove `httpAgent` to use HTTP/2, or pass `http2: false` to select ' +
-            'HTTP/1.1 explicitly and silence this warning.',
-        );
-      }
-    } else {
-      // New default: HTTP/2.
-      useHttp2 = true;
-    }
-
     super({
       baseURL: options.baseURL!,
       baseURLOverridden: baseURL ? baseURL !== 'https://api.runloop.ai' : false,
       timeout: options.timeout ?? 30000 /* 30 seconds */,
       httpAgent: options.httpAgent,
       maxRetries: options.maxRetries,
-      fetch:
-        options.fetch ??
-        (useHttp2 ?
-          makeHttp2Fetch(typeof options.http2 === 'object' ? options.http2 : undefined)
-        : undefined),
+      // HTTP/2 is the default transport on Node; a custom `fetch` always wins.
+      // See `resolveHttp2Fetch` for the `http2` / `httpAgent` resolution.
+      fetch: options.fetch ?? resolveHttp2Fetch(options),
     });
 
     const customHeadersEnv = Core.readEnv('RUNLOOP_CUSTOM_HEADERS');

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -17,8 +17,14 @@
 
 import { Readable } from 'node:stream';
 import { H2Pool, type H2PoolOptions } from './pool';
+import type { H2Response } from './response';
 import { MultipartBody } from '../../_shims/MultipartBody';
+import { Response } from 'node-fetch';
 import { type Fetch } from '../../core';
+
+// Statuses that must not carry a body per the Fetch spec; node-fetch's Response
+// rejects a non-null body for these.
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
 const MIN_NODE_MAJOR = 18;
 
@@ -61,6 +67,25 @@ async function normalizeBody(body: unknown): Promise<string | Buffer | null> {
   if (ArrayBuffer.isView(body)) return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
   if (body instanceof ArrayBuffer) return Buffer.from(body);
   return String(body);
+}
+
+/**
+ * Adapt an internal {@link H2Response} to a standard node-fetch `Response`, so
+ * callers get the same type the default (HTTP/1.1) transport returns — including
+ * `instanceof Response`. Body streaming is preserved: the H2 body is a web
+ * `ReadableStream`, which node-fetch consumes as a Node `Readable`.
+ */
+function toFetchResponse(h2: H2Response): Response {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of h2.headers.entries()) headers[key] = value;
+
+  const body = NULL_BODY_STATUSES.has(h2.status) ? null : Readable.fromWeb(h2.body as any);
+  const response = new Response(body as any, { status: h2.status, headers });
+
+  // node-fetch derives `url` from the request internals it never saw; expose the
+  // real request URL (`Response.url` is a prototype getter, shadowed here).
+  Object.defineProperty(response, 'url', { value: h2.url, configurable: true });
+  return response;
 }
 
 /**
@@ -109,7 +134,8 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
     }
 
     const pool = getPool(parsed.origin);
-    return pool.request(path, method.toUpperCase(), reqHeaders, body, signal) as any;
+    const h2resp = await pool.request(path, method.toUpperCase(), reqHeaders, body, signal);
+    return toFetchResponse(h2resp) as any;
   }) as H2Fetch;
 
   h2Fetch.close = async () => {

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -23,8 +23,9 @@ import { Response } from 'node-fetch';
 import { type Fetch } from '../../core';
 
 // Statuses that must not carry a body per the Fetch spec; node-fetch's Response
-// rejects a non-null body for these.
-const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+// rejects a non-null body for these. (101 is an HTTP/1.1 upgrade status and can't
+// occur over HTTP/2, so it's omitted.)
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 
 const MIN_NODE_MAJOR = 18;
 
@@ -84,7 +85,7 @@ function toFetchResponse(h2: H2Response): Response {
 
   // node-fetch derives `url` from the request internals it never saw; expose the
   // real request URL (`Response.url` is a prototype getter, shadowed here).
-  Object.defineProperty(response, 'url', { value: h2.url, configurable: true });
+  Object.defineProperty(response, 'url', { value: h2.url, writable: true, configurable: true });
   return response;
 }
 

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -1,10 +1,10 @@
 /**
  * A high-performance HTTP/2 fetch adapter built on Node's native `node:http2`.
  *
- * Replaces undici for HTTP/2 transport. Manages a pool of persistent H2 sessions
- * per origin, multiplexing requests as concurrent streams. Each session handles up
- * to the server-advertised MAX_CONCURRENT_STREAMS; the pool auto-scales between
- * minConnections and maxConnections as load requires.
+ * Manages a pool of persistent H2 sessions per origin, multiplexing requests as
+ * concurrent streams. Each session handles up to the server-advertised
+ * MAX_CONCURRENT_STREAMS; the pool auto-scales between minConnections and
+ * maxConnections as load requires.
  *
  * Usage:
  *   const fetch = createH2Fetch({ maxConnections: 20 });

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -79,6 +79,10 @@ export class H2Session {
         // Enlarge the session-level flow-control window so the server can push
         // large responses without stalling on WINDOW_UPDATE round trips.
         session.setLocalWindowSize(DEFAULT_INITIAL_WINDOW_SIZE);
+        // An idle pooled session must not keep the process alive; each in-flight
+        // request re-refs the socket (see `request`) and it is unref'd again once
+        // the stream count returns to zero.
+        session.unref();
         resolve();
       });
 
@@ -140,6 +144,9 @@ export class H2Session {
 
       const stream = this._session!.request(h2Headers);
       this._activeStreams++;
+      // Keep the process alive while this request is outstanding; idle sessions
+      // are unref'd (see `connect` and `cleanup`).
+      this._session!.ref();
 
       let settled = false;
       let cleaned = false;
@@ -155,6 +162,7 @@ export class H2Session {
           stream.on('error', () => {});
           stream.destroy();
           this._activeStreams--;
+          if (this._activeStreams === 0) this._session?.unref();
           reject(createAbortError());
           return;
         }
@@ -165,6 +173,7 @@ export class H2Session {
         if (cleaned) return;
         cleaned = true;
         this._activeStreams--;
+        if (this._activeStreams === 0) this._session?.unref();
         if (signal) signal.removeEventListener('abort', onAbort);
         if (this._state === SessionState.DRAINING && this._activeStreams === 0) {
           this._close();

--- a/src/lib/http2-transport.ts
+++ b/src/lib/http2-transport.ts
@@ -1,0 +1,78 @@
+import { makeHttp2Fetch } from '../_shims/index';
+import { type Fetch } from '../core';
+import type { H2FetchOptions } from './h2-transport';
+
+/**
+ * Transport-selection logic for the client. Kept out of the generated
+ * `src/index.ts` so the generated file only holds a one-line call-site hook.
+ *
+ * HTTP/2 is the default on Node. The web/Deno shims make {@link makeHttp2Fetch}
+ * a no-op that returns the platform `fetch`, so this is effectively Node-only.
+ */
+
+// A single HTTP/2 transport shared by every client that uses the default pool,
+// so short-lived clients don't each open (and leak) their own H2 sessions.
+// Clients that pass explicit `H2FetchOptions` get a dedicated pool, since they
+// asked to tune it.
+let sharedDefaultFetch: Fetch | undefined;
+
+function getSharedDefaultFetch(): Fetch {
+  return (sharedDefaultFetch ??= makeHttp2Fetch());
+}
+
+// Each warning is emitted at most once per process. Module-scoped flags mirror
+// the `fileFromPathWarned` pattern in _shims/node-runtime.ts.
+let httpAgentIgnoredWarned = false;
+let httpAgentFallbackWarned = false;
+
+function warnHttpAgentIgnored(): void {
+  if (httpAgentIgnoredWarned) return;
+  httpAgentIgnoredWarned = true;
+  console.warn(
+    '[runloop] `httpAgent` is ignored when `http2` is set: the HTTP/2 transport manages ' +
+      'its own connections. To tune the H2 pool, pass options as `http2` ' +
+      '(e.g. `http2: { maxConnections: 20 }`).',
+  );
+}
+
+function warnHttpAgentFallback(): void {
+  if (httpAgentFallbackWarned) return;
+  httpAgentFallbackWarned = true;
+  console.warn(
+    '[runloop] HTTP/2 is the default transport, but `httpAgent` is set, so this client ' +
+      'uses HTTP/1.1. Remove `httpAgent` to use HTTP/2, or pass `http2: false` to select ' +
+      'HTTP/1.1 explicitly and silence this warning.',
+  );
+}
+
+export interface Http2TransportOptions {
+  http2?: boolean | H2FetchOptions | undefined;
+  httpAgent?: unknown;
+}
+
+/**
+ * Resolve the `fetch` implementation for the transport, or `undefined` to fall
+ * back to the default HTTP/1.1 (`node-fetch`) transport. Only called when the
+ * caller did not supply a custom `fetch` (a custom `fetch` always wins).
+ *
+ * - `http2: false` → HTTP/1.1.
+ * - `http2: true` / omitted → the shared default HTTP/2 pool.
+ * - `http2: H2FetchOptions` → a dedicated HTTP/2 pool tuned with those options.
+ * - a bare `httpAgent` (no explicit `http2`) → HTTP/1.1, so existing agents keep
+ *   working; warns once since it overrides the HTTP/2 default.
+ */
+export function resolveHttp2Fetch(options: Http2TransportOptions): Fetch | undefined {
+  if (options.http2 === false) return undefined;
+
+  if (options.http2) {
+    if (options.httpAgent) warnHttpAgentIgnored();
+    return typeof options.http2 === 'object' ? makeHttp2Fetch(options.http2) : getSharedDefaultFetch();
+  }
+
+  if (options.httpAgent) {
+    warnHttpAgentFallback();
+    return undefined;
+  }
+
+  return getSharedDefaultFetch();
+}

--- a/src/lib/http2-transport.ts
+++ b/src/lib/http2-transport.ts
@@ -3,11 +3,15 @@ import { type Fetch } from '../core';
 import type { H2FetchOptions } from './h2-transport';
 
 /**
- * Transport-selection logic for the client. Kept out of the generated
- * `src/index.ts` so the generated file only holds a one-line call-site hook.
+ * Transport-selection logic for the client, kept out of the generated
+ * `src/index.ts` (which holds only a one-line call-site hook).
  *
- * HTTP/2 is the default on Node. The web/Deno shims make {@link makeHttp2Fetch}
- * a no-op that returns the platform `fetch`, so this is effectively Node-only.
+ * This selection matters only on Node.js. There the SDK's default transport is
+ * `node-fetch`, which speaks HTTP/1.1, so using HTTP/2 means swapping in the
+ * dedicated `node:http2` transport that {@link makeHttp2Fetch} builds. On
+ * browsers, Deno, and Bun the platform `fetch` already negotiates HTTP/2, so the
+ * shim's {@link makeHttp2Fetch} simply returns that platform `fetch` and this
+ * whole resolution is effectively a no-op.
  */
 
 // A single HTTP/2 transport shared by every client that uses the default pool,

--- a/src/lib/http2-transport.ts
+++ b/src/lib/http2-transport.ts
@@ -64,6 +64,11 @@ export interface Http2TransportOptions {
  * - `http2: H2FetchOptions` → a dedicated HTTP/2 pool tuned with those options.
  * - a bare `httpAgent` (no explicit `http2`) → HTTP/1.1, so existing agents keep
  *   working; warns once since it overrides the HTTP/2 default.
+ *
+ * `httpAgent` never applies to the HTTP/2 path: a Node `http.Agent` configures
+ * HTTP/1.1 socket pooling, which has no equivalent in HTTP/2's multiplexed model
+ * (its knobs live on `H2FetchOptions`). So the H2 branches ignore it, warning
+ * once, rather than pretending to honor it.
  */
 export function resolveHttp2Fetch(options: Http2TransportOptions): Fetch | undefined {
   if (options.http2 === false) return undefined;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -100,7 +100,7 @@ describe('instantiate client', () => {
   test('custom fetch wins over http2', async () => {
     // When both `fetch` and `http2` are provided, the custom fetch must be used —
     // the h2 adapter should not run. Locks in src/index.ts:
-    //   fetch: options.fetch ?? (useHttp2 ? makeHttp2Fetch(...) : undefined)
+    //   fetch: options.fetch ?? resolveHttp2Fetch(options)
     const customFetch = jest.fn((url: RequestInfo) =>
       Promise.resolve(
         new Response(JSON.stringify({ url, custom: true }), {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -99,8 +99,8 @@ describe('instantiate client', () => {
 
   test('custom fetch wins over http2', async () => {
     // When both `fetch` and `http2` are provided, the custom fetch must be used —
-    // the undici (h2) adapter should not run. Locks in src/index.ts:
-    //   fetch: options.fetch ?? (options.http2 ? makeHttp2Fetch(...) : undefined)
+    // the h2 adapter should not run. Locks in src/index.ts:
+    //   fetch: options.fetch ?? (useHttp2 ? makeHttp2Fetch(...) : undefined)
     const customFetch = jest.fn((url: RequestInfo) =>
       Promise.resolve(
         new Response(JSON.stringify({ url, custom: true }), {
@@ -135,17 +135,58 @@ describe('instantiate client', () => {
   test('warns once when http2 and httpAgent are combined', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      // http2 alone (or httpAgent alone) does not warn.
+      // Explicit http2 alone does not warn.
       new Runloop({ baseURL: 'http://localhost:5000/', bearerToken: 'My Bearer Token', http2: true });
       expect(warn).not.toHaveBeenCalled();
 
       // Combining them warns — exactly once per process (module-scoped flag), so the
       // second construction is silent.
-      const opts = { baseURL: 'http://localhost:5000/', bearerToken: 'My Bearer Token', httpAgent: {} as any };
+      const opts = {
+        baseURL: 'http://localhost:5000/',
+        bearerToken: 'My Bearer Token',
+        httpAgent: {} as any,
+      };
       new Runloop({ ...opts, http2: true });
       new Runloop({ ...opts, http2: true });
       expect(warn).toHaveBeenCalledTimes(1);
       expect(String(warn.mock.calls[0]?.[0])).toContain('httpAgent');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('httpAgent without explicit http2 stays on HTTP/1.1 and warns once', () => {
+    // HTTP/2 is the default, but a bare `httpAgent` keeps the client on HTTP/1.1 so
+    // existing agents keep working. The fallback warns once (module-scoped flag).
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const opts = {
+        baseURL: 'http://localhost:5000/',
+        bearerToken: 'My Bearer Token',
+        httpAgent: {} as any,
+      };
+      new Runloop(opts);
+      new Runloop(opts);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain('HTTP/1.1');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('http2: false opts out of the default HTTP/2 transport without warning', () => {
+    // Explicit opt-out is silent even alongside an httpAgent — the user has chosen
+    // HTTP/1.1 deliberately.
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const client = new Runloop({
+        baseURL: 'http://localhost:5000/',
+        bearerToken: 'My Bearer Token',
+        httpAgent: {} as any,
+        http2: false,
+      });
+      expect(client).toBeDefined();
+      expect(warn).not.toHaveBeenCalled();
     } finally {
       warn.mockRestore();
     }

--- a/tests/lib/h2-transport/integration.test.ts
+++ b/tests/lib/h2-transport/integration.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { createH2Fetch } from '../../../src/lib/h2-transport/index';
 import { cleanupCerts, testTls } from './helpers/certs';
 import { defaultHandler, startTestServer, TestServer } from './helpers/testServer';
@@ -35,7 +36,9 @@ describe('integration through createH2Fetch', () => {
     } as any)) as any;
     expect(r.headers.get('content-type')).toBe('text/event-stream');
 
-    const reader = r.body.getReader();
+    // `Response.body` is a node-fetch Node `Readable`; wrap it as a web stream
+    // to exercise incremental `getReader()` consumption.
+    const reader = Readable.toWeb(r.body).getReader();
     const decoder = new TextDecoder();
     let buf = '';
     while (true) {

--- a/tests/lib/http2-transport.test.ts
+++ b/tests/lib/http2-transport.test.ts
@@ -1,0 +1,48 @@
+import { resolveHttp2Fetch } from '../../src/lib/http2-transport';
+
+describe('resolveHttp2Fetch', () => {
+  test('defaults to HTTP/2 and shares a single pool across clients', () => {
+    const a = resolveHttp2Fetch({});
+    const b = resolveHttp2Fetch({});
+    const explicitTrue = resolveHttp2Fetch({ http2: true });
+    expect(a).toBeDefined();
+    // Same instance — short-lived clients must not each open their own pool.
+    expect(b).toBe(a);
+    expect(explicitTrue).toBe(a);
+  });
+
+  test('http2: false falls back to HTTP/1.1 (undefined fetch)', () => {
+    expect(resolveHttp2Fetch({ http2: false })).toBeUndefined();
+  });
+
+  test('H2FetchOptions gets a dedicated pool, not the shared default', () => {
+    const shared = resolveHttp2Fetch({});
+    const tuned = resolveHttp2Fetch({ http2: { maxConnections: 2 } });
+    expect(tuned).toBeDefined();
+    expect(tuned).not.toBe(shared);
+  });
+
+  test('bare httpAgent keeps HTTP/1.1 and warns once', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolveHttp2Fetch({ httpAgent: {} })).toBeUndefined();
+      expect(resolveHttp2Fetch({ httpAgent: {} })).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain('HTTP/1.1');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('http2 + httpAgent uses H2 and warns that httpAgent is ignored', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const shared = resolveHttp2Fetch({});
+      expect(resolveHttp2Fetch({ http2: true, httpAgent: {} })).toBe(shared);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain('httpAgent');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Why HTTP/2 (performance motivation)

On Node.js the previous default transport (`node-fetch` over HTTP/1.1) opens a **new TCP + TLS connection per concurrent request** — HTTP/1.1 can't multiplex, so a burst of N in-flight requests means up to N handshakes and, once the socket pool is saturated, requests queue waiting for a free connection. That connection setup and queueing lands squarely in the **tail latency**.

The SDK's `node:http2` transport multiplexes many concurrent requests as streams over a **small shared pool of connections**: one handshake amortized across many requests, no per-request connection setup, and no pool-exhaustion queueing. Runloop SDK traffic is bursty and highly concurrent (agents firing many devbox operations in parallel), which is exactly the workload HTTP/2 multiplexing is built for. Bulk transfers stay at parity because the H2 session's flow-control window is sized so large streams aren't RTT-bound.

## End-to-end benchmark (dev)

Measured against `dev` from this branch (Node v24), same client config with only the `http2` flag flipped. Indicative single-run results from a shared environment — compare like-for-like, not as absolute targets.

### Request handling under high concurrency (primary)

The SDK's own load harness — `loadtest/loadtest.ts` (from #798) — fires many `devboxes.create` calls **concurrently at a deliberately nonexistent blueprint** (`bp_nonexistent_loadtest_00000`). Every request fails fast server-side (all HTTP `400`, **zero devboxes created**), which isolates client + server *request handling* from actual provisioning — i.e. purely "can the stack absorb a burst of requests at once." Run here at 2,000 concurrent requests (reduced from the harness default; the sandbox FD limit is 4096), `http2` set explicitly per pass:

| Metric | HTTP/1.1 | HTTP/2 | Improvement |
|---|---|---|---|
| Wall clock (2,000 reqs) | 16.13 s | **0.98 s** | **~16× faster** |
| Throughput | 124 req/s | **2,037 req/s** | **~16×** |
| p50 latency | 6,447 ms | **744 ms** | ~8.7× |
| p95 latency | 11,952 ms | **908 ms** | ~13× |
| p99 latency | 16,087 ms | **969 ms** | ~16.6× |
| Result | 2000× `400` | 2000× `400` | — |

Under a 2,000-request burst, HTTP/1.1 (`node-fetch`) opens a socket per request and serializes behind connection setup + pool limits, so latency balloons into multi-second territory; HTTP/2 multiplexes the whole burst over a small connection pool and clears it in under a second. This is the workload the default flip is aimed at.

### Concurrent lightweight reads (secondary)

A smaller micro-benchmark firing `N` concurrent `devboxes.list({ limit: 1 })` reads (warmup excluded, 0 failures) — a lighter endpoint where server processing dominates the median, so the win shows in the tail:

| Concurrency | Transport | req/s | p50 | p95 | p99 |
|---|---|---|---|---|---|
| 40 (×5) | HTTP/1.1 | 149.5 | 203 | 441 | 460 |
| 40 (×5) | **HTTP/2** | **179.4** | 202 | **220** | **228** |
| 100 (×3) | HTTP/1.1 | 192.2 | 457 | 630 | 638 |
| 100 (×3) | **HTTP/2** | **209.8** | 429 | **478** | **480** |

### Concurrent large downloads (throughput parity)

8 × 10 MB via `downloadFile`, md5-verified (exercises the H2 flow-control window):

| Transport | Effective throughput |
|---|---|
| HTTP/1.1 | 55.7 MB/s |
| **HTTP/2** | **62.0 MB/s** |

Bulk throughput is at parity (slightly ahead here), with all payloads byte-identical — HTTP/2 is not a regression for large transfers.

## Summary

Makes **HTTP/2 the default transport on Node.js**. The SDK's native `node:http2` transport multiplexes many concurrent requests over a small shared pool of TLS connections instead of opening one connection per request. Previously HTTP/2 was opt-in (`http2: true`); this flips the default from `false` → `true`.

- **Web / Deno / Bun**: unaffected — the platform `fetch` already speaks HTTP/2, and the H2 shim is a no-op there.
- **Custom `fetch`**: always wins over `http2`.
- **Opt out**: `http2: false` selects the HTTP/1.1 `node-fetch` transport.

## Transport resolution

`httpAgent` only applies to the HTTP/1.1 path — the H2 pool manages its own connections. To avoid silently changing behavior for existing users who pass an `httpAgent`, resolution is:

| `http2` | `httpAgent` | Result |
|---|---|---|
| unset | unset | **HTTP/2** (new default, shared pool) |
| unset | set | **HTTP/1.1**, one-time warning (honors the agent) |
| `false` | any | HTTP/1.1, silent |
| `true` | any | HTTP/2 (shared pool); warns once if `httpAgent` also set |
| `H2FetchOptions` | any | HTTP/2 with a dedicated, tuned pool |
| any | + custom `fetch` | custom fetch |

No existing `httpAgent` user is silently moved off HTTP/1.1: they get a one-time notice and can drop `httpAgent` to adopt H2 or pass `http2: false` to silence it.

## Shared connection pool

All clients using the default transport share a **single** HTTP/2 pool, so short-lived clients (e.g. one per request) don't each open — and leak — their own H2 sessions. Explicit `H2FetchOptions` still get a dedicated pool, since that's deliberate tuning.

## Transport correctness

Making H2 the default surfaced two behaviors of the transport that only mattered once non-opt-in clients used it, both fixed here:

- **`Response` contract** — the H2 fetch now returns a standard `node-fetch` `Response`, so `.asResponse()` satisfies `instanceof Response` like the HTTP/1.1 transport does. Streaming is preserved (the H2 body is consumed as a Node `Readable`).
- **Process lifetime** — idle pooled H2 sessions are `unref`'d (and `ref`'d only while a request is in flight), so a short Node script or test process exits normally instead of hanging on open sockets.

## Code organization

The transport-selection logic and its one-time warnings live in a handwritten helper, `src/lib/http2-transport.ts`. The generated `src/index.ts` keeps only a one-line call-site hook, so regeneration stays clean.

## Docs

Rewrote the README **HTTP/2 transport** section for H2-as-default and the `http2: false` opt-out, and corrected stale copy that still described the previous undici-based transport (it's native `node:http2`).

## Release

Ships as a **minor** version bump; `http2: false` is the documented opt-out.

## Test plan

- [x] `tsc --noEmit` clean.
- [x] Unit coverage for transport resolution: default→H2 with a shared pool, `http2: false` opt-out, dedicated pool for `H2FetchOptions`, and both one-time warnings.
- [x] Full `jest` suite against the mock server: **880 passed, 6 skipped**, including all `tests/api-resources/**` and the h2-transport suite; the process exits promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

