### PR TITLE
fix(smoketests): raise devbox snapshot test timeouts to 120s

### DIFF
--- a/tests/smoketests/snapshots.test.ts
+++ b/tests/smoketests/snapshots.test.ts
@@ -29,7 +29,7 @@ describe('smoketest: devbox snapshots', () => {
         await client.devboxes.shutdown(devbox.id);
       }
     }
-  }, 30_000);
+  }, 120_000);
 
   test('launch devbox from snapshot (deprecated polling path)', async () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
@@ -54,5 +54,5 @@ describe('smoketest: devbox snapshots', () => {
         await client.devboxes.shutdown(devbox.id);
       }
     }
-  }, 30_000);
+  }, 120_000);
 });


### PR DESCRIPTION
## **User description**
## Description

Raises the per-test Jest timeout on both tests in the `devbox snapshots` suite (`tests/smoketests/snapshots.test.ts`) from **30s to 120s**.

## Motivation

These two tests hard-coded a `30_000` per-test timeout that *overrode* the smoketest default of **300s** (`jest.config.ts` → `testTimeout: runSmoketests ? 300000 : 120000`). They were the only snapshot-flow tests capped at 30s.

Under concurrent CI load (`smoke-tests.yml` runs the full suite with `--maxWorkers=800%`), `createAndAwaitRunning` + `snapshotDisk` tail latency climbs well past 30s. Repro'd against dev:

| Concurrency | Max observed test duration |
|-------------|----------------------------|
| 1 (sequential) | 3.7s |
| 10 | 9.7s |
| 30 | 21.8s |

The backend serves these operations in batches of ~4, adding ~3s of queued latency per tier — so the 30s cap breaches under enough simultaneous devbox creation (the failing run also had `axon.test.ts` at 83s). This matches the observed CI failure: `snapshot devbox (30078 ms)` → `Exceeded timeout of 30000 ms`.

120s gives comfortable headroom while staying well under the 300s smoketest default, so a genuinely hung create/snapshot still fails fast.

## Changes

- `tests/smoketests/snapshots.test.ts`: `snapshot devbox` timeout 30s → 120s
- `tests/smoketests/snapshots.test.ts`: `launch devbox from snapshot (deprecated polling path)` timeout 30s → 120s (same `createAndAwaitRunning`-under-load path)

## Testing

- [ ] Unit tests added
- [ ] Integration tests added
- [x] Smoke Tests added/updated
- [x] Tested locally

Ran the edited test against dev: passes sequentially (10/10) and under 10- and 30-way parallelism (30/30, 60/60) — no failures, tail latency ~22s stays under the new 120s cap.

## Breaking Changes

None.

## Note

The timeout bump de-flakes CI but does not address the underlying ~4-wide batching / throughput ceiling on devbox create+snapshot, which may warrant a separate backend investigation.

## Checklist

- [x] PR title follows Conventional Commits format
- [ ] Documentation updated (if needed)
- [ ] Breaking changes documented (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Raise flaky devbox snapshot smoketest timeouts**

### What Changed
- The two devbox snapshot smoke tests now allow up to 120 seconds instead of 30 seconds
- Snapshot creation and launching from a snapshot no longer fail as often under CI load when these steps take longer than expected

### Impact
`✅ Fewer flaky snapshot smoke test failures`
`✅ More reliable CI runs for devbox snapshots`
`✅ Fewer timeout errors during busy test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
