### PR TITLE
fix(smoketests): align blueprint test timeouts with long-poll budgets

### DIFF
--- a/tests/smoketests/blueprints.test.ts
+++ b/tests/smoketests/blueprints.test.ts
@@ -1,5 +1,4 @@
-import { BlueprintView } from '@runloop/api-client/resources/blueprints';
-import { makeClient, SHORT_TIMEOUT, uniqueName } from './utils';
+import { cleanUpBlueprintsByName, LONG_TIMEOUT, makeClient, MEDIUM_TIMEOUT, uniqueName } from './utils';
 import { DevboxView } from '@runloop/api-client/resources/devboxes';
 
 const client = makeClient();
@@ -13,7 +12,7 @@ describe('smoketest: blueprints', () => {
     let blueprintName = uniqueName('bp');
 
     afterAll(async () => {
-      await client.blueprints.delete(blueprintId!);
+      await cleanUpBlueprintsByName(client, blueprintName);
     });
 
     test(
@@ -24,13 +23,13 @@ describe('smoketest: blueprints', () => {
             name: blueprintName,
           },
           {
-            longPoll: { timeoutMs: 30 * 60 * 1000 },
+            longPoll: { timeoutMs: MEDIUM_TIMEOUT },
           },
         );
         expect(created.status).toBe('build_complete');
         blueprintId = created.id;
       },
-      SHORT_TIMEOUT,
+      LONG_TIMEOUT,
     );
 
     test(
@@ -44,7 +43,7 @@ describe('smoketest: blueprints', () => {
               launch_parameters: { resource_size_request: 'X_SMALL', keep_alive_time_seconds: 60 * 5 }, // 5 minutes
             },
             {
-              longPoll: { timeoutMs: 20 * 60 * 1000 },
+              longPoll: { timeoutMs: MEDIUM_TIMEOUT },
             },
           );
           expect(devbox.blueprint_id).toBe(blueprintId);
@@ -54,7 +53,7 @@ describe('smoketest: blueprints', () => {
           }
         }
       },
-      SHORT_TIMEOUT,
+      LONG_TIMEOUT,
     );
 
     test(
@@ -68,7 +67,7 @@ describe('smoketest: blueprints', () => {
               launch_parameters: { resource_size_request: 'X_SMALL', keep_alive_time_seconds: 60 * 5 }, // 5 minutes
             },
             {
-              longPoll: { timeoutMs: 20 * 60 * 1000 },
+              longPoll: { timeoutMs: MEDIUM_TIMEOUT },
             },
           );
           expect(devbox.blueprint_id).toBeTruthy();
@@ -78,7 +77,7 @@ describe('smoketest: blueprints', () => {
           }
         }
       },
-      SHORT_TIMEOUT,
+      LONG_TIMEOUT,
     );
   });
 
@@ -89,9 +88,8 @@ describe('smoketest: blueprints', () => {
     test.concurrent(
       'create blueprint with secret in Dockerfile and await build',
       async () => {
-        let bpt: BlueprintView | undefined;
         try {
-          bpt = await client.blueprints.createAndAwaitBuildCompleted(
+          const bpt = await client.blueprints.createAndAwaitBuildCompleted(
             {
               name: secretsBlueprintName,
               dockerfile:
@@ -101,19 +99,17 @@ describe('smoketest: blueprints', () => {
               },
             },
             {
-              longPoll: { timeoutMs: 30 * 60 * 1000 },
+              longPoll: { timeoutMs: MEDIUM_TIMEOUT },
             },
           );
 
           expect(bpt.status).toBe('build_complete');
           expect(bpt.parameters.secrets?.['GITHUB_TOKEN']).toBe('GITHUB_TOKEN_FOR_SMOKETESTS');
         } finally {
-          if (bpt) {
-            await client.blueprints.delete(bpt.id);
-          }
+          await cleanUpBlueprintsByName(client, secretsBlueprintName);
         }
       },
-      SHORT_TIMEOUT,
+      LONG_TIMEOUT,
     );
   });
 });

--- a/tests/smoketests/utils.ts
+++ b/tests/smoketests/utils.ts
@@ -40,6 +40,22 @@ export const MEDIUM_TIMEOUT = 300_000;
 export const LONG_TIMEOUT = 600_000;
 
 /**
+ * Helper to clean up every blueprint with the given name, ignoring errors if
+ * already deleted. Looks blueprints up by name rather than taking an ID so that
+ * cleanup still runs when a create-and-await call timed out before returning one.
+ */
+export async function cleanUpBlueprintsByName(client: Runloop, name: string): Promise<void> {
+  try {
+    const page = await client.blueprints.list({ name });
+    for (const blueprint of page.blueprints) {
+      await client.blueprints.delete(blueprint.id);
+    }
+  } catch {
+    // Already deleted or never created, ignore
+  }
+}
+
+/**
  * Helper to clean up a network policy, ignoring errors if already deleted.
  */
 export async function cleanUpPolicy(policy: NetworkPolicy | undefined): Promise<void> {


### PR DESCRIPTION
## **User description**
## Description

The blueprint smoketests pass a 120s (`SHORT_TIMEOUT`) jest timeout while asking the SDK to long-poll for up to 20–30 minutes. The jest budget always wins, so any build slower than 120s fails as a bare `Exceeded timeout of 120000 ms for a test` with no SDK error, no build state, and no cleanup — jest aborts the test before `finally` runs.

That is what broke the prod deploy smoketest in [runloopai/runloop run 31224813985](https://github.com/runloopai/runloop/actions/runs/31224813985/job/93017627080): `create blueprint with secrets and await build` timed out at 120002 ms (http1) and 120001 ms (http2), while the sibling `create blueprint and await build` in the same file passed in 12675 ms and other Dockerfile builds in the same run completed in 25–50s. The environment was mid-deploy and prod blueprint builds were running long that hour; the test converted normal build variance into a deploy-blocking failure with zero diagnostics, and leaked the blueprint on the way out.

## Motivation

A smoketest should fail with the reason the build didn't finish, not with a stopwatch that expires 15× earlier than the budget it's supervising — and it should never leak resources in prod when it does fail.

## Changes

- Cap `longPoll.timeoutMs` at `MEDIUM_TIMEOUT` (5 min) and raise the jest timeouts to `LONG_TIMEOUT` (10 min) for the four blueprint tests, so the SDK's own timeout fires first and reports the terminal state it was waiting on.
- Add `cleanUpBlueprintsByName` to `tests/smoketests/utils.ts` and use it in `afterAll` and the secrets test's `finally`, so cleanup works even when the create-and-await call timed out before returning an id.
- Drop the now-unused `let bpt` / `BlueprintView` import that the cleanup change orphaned.

No production SDK code is touched; this is test-only.

## Testing

- [ ] Unit tests added/updated
- [x] Smoke Tests added/updated
- [x] Manual testing performed

Test-only change; verification is the smoketest workflow itself (both the http1 and http2 transports).

## Breaking Changes

None.

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the code has been performed
- [x] Changes generate no new warnings


___

## **CodeAnt-AI Description**
Prevent blueprint smoketests from timing out before builds finish

### What Changed
- Blueprint build and devbox startup tests now allow up to 10 minutes for completion while limiting long-polling to 5 minutes.
- Failed or slow operations can report their build or startup outcome instead of being stopped by the previous 2-minute test limit.
- Cleanup now finds blueprints by name, including cases where a timed-out operation never returned an ID, and removes them after tests finish.

### Impact
`✅ Fewer deploy-blocking smoketest timeouts`
`✅ Clearer build and startup failure results`
`✅ Fewer leaked test blueprints`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
