### PR TITLE
feat(devboxes): use optimistic create endpoint

### DIFF
--- a/src/resources/devboxes/devboxes.ts
+++ b/src/resources/devboxes/devboxes.ts
@@ -131,7 +131,13 @@ export class Devboxes extends APIResource {
     options?: LongPollRequestOptions<DevboxView>,
   ): Promise<DevboxView> {
     const { longPoll, polling, ...requestOptions } = options ?? {};
-    const devbox = await this.create(body, requestOptions);
+    const devbox = (await this._client.post('/v1/devboxes/create_and_await_running', {
+      body: body ?? {},
+      ...requestOptions,
+    })) as DevboxView;
+    if (devbox.status === 'running') {
+      return devbox;
+    }
     return this.awaitRunning(devbox.id, { ...requestOptions, longPoll, polling });
   }
   /**

--- a/tests/api-resources/devboxes/devboxes.test.ts
+++ b/tests/api-resources/devboxes/devboxes.test.ts
@@ -716,7 +716,7 @@ describe('resource devboxes', () => {
     expect(mockPost).toHaveBeenCalledTimes(2);
 
     // Check create call
-    expect(mockPost).toHaveBeenNthCalledWith(1, '/v1/devboxes', {
+    expect(mockPost).toHaveBeenNthCalledWith(1, '/v1/devboxes/create_and_await_running', {
       body: { name: 'test-devbox' },
     });
 
@@ -731,16 +731,28 @@ describe('resource devboxes', () => {
     mockPost.mockRestore();
   });
 
+  test('createAndAwaitRunning: returns an optimistic running response without polling', async () => {
+    const mockPost = jest.spyOn(client.devboxes['_client'], 'post');
+    mockPost.mockResolvedValueOnce({ id: 'new-devbox-id', status: 'running' });
+
+    const result = await client.devboxes.createAndAwaitRunning({ name: 'test-devbox' });
+
+    expect(result).toEqual({ id: 'new-devbox-id', status: 'running' });
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost).toHaveBeenCalledWith('/v1/devboxes/create_and_await_running', {
+      body: { name: 'test-devbox' },
+    });
+  });
+
   test('createAndAwaitRunning: handles creation failure', async () => {
     const mockPost = jest.spyOn(client.devboxes['_client'], 'post');
 
-    const createError = new Error('Creation failed');
-    mockPost.mockRejectedValueOnce(createError);
+    const createError = new APIError(400, undefined, 'Creation failed', {});
+    mockPost.mockRejectedValue(createError);
 
     await expect(client.devboxes.createAndAwaitRunning()).rejects.toThrow('Creation failed');
 
-    expect(mockPost).toHaveBeenCalledTimes(1);
-    expect(mockPost).toHaveBeenCalledWith('/v1/devboxes', { body: {} });
+    expect(mockPost).toHaveBeenCalledWith('/v1/devboxes/create_and_await_running', { body: {} });
 
     mockPost.mockRestore();
   });


### PR DESCRIPTION
## **User description**
## Summary

- use the optimistic devbox create endpoint inside createAndAwaitRunning
- return immediately when the server observes running
- retain the existing long-poll fallback for transitional responses
- keep the raw endpoint out of the generated public API surface

## Testing

- yarn lint
- focused createAndAwaitRunning Jest tests

Depends on runloopai/runloop#10859.


___

## **CodeAnt-AI Description**
Create devboxes through the optimistic endpoint and return ready instances immediately

### What Changed
- Devbox creation now uses the endpoint that can return a running devbox immediately
- Running devboxes are returned without an additional status wait
- Devboxes still wait for running, failure, or shutdown when creation is still in progress
- Added coverage for immediate running responses and creation failures

### Impact
`✅ Faster access to ready devboxes`
`✅ Fewer unnecessary status checks`
`✅ Preserved provisioning wait behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
