### PR TITLE
fix(errors): normalize lifecycle and tunnel failures

### DIFF
--- a/.github/workflows/sdk-coverage.yml
+++ b/.github/workflows/sdk-coverage.yml
@@ -58,7 +58,7 @@ jobs:
         id: tests
         run: |
           set -o pipefail
-          yarn test:objects-coverage --maxWorkers=800% --color 2>&1 | \
+          yarn test:objects-coverage --color 2>&1 | \
             tee -i test-output.log
 
       - name: Upload coverage report
@@ -199,4 +199,3 @@ jobs:
                 body: comment
               });
             }
-

--- a/src/core.ts
+++ b/src/core.ts
@@ -64,6 +64,7 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
   const { response } = props;
   let responseReader: 'json' | 'text' | undefined;
   let bodyUsedBeforeRead = false;
+  let bodyLockedBeforeRead = false;
   try {
     if (props.options.stream) {
       debug('response', response.status, response.url, response.headers, response.body);
@@ -99,6 +100,7 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
 
       responseReader = 'json';
       bodyUsedBeforeRead = response.bodyUsed;
+      bodyLockedBeforeRead = (response.body as any)?.locked === true;
       const json = await response.json();
 
       debug('response', response.status, response.url, response.headers, json);
@@ -108,6 +110,7 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
 
     responseReader = 'text';
     bodyUsedBeforeRead = response.bodyUsed;
+    bodyLockedBeforeRead = (response.body as any)?.locked === true;
     const text = await response.text();
     debug('response', response.status, response.url, response.headers, text);
 
@@ -119,7 +122,9 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
     if (
       cause.name === 'TypeError' &&
       responseReader &&
-      (bodyUsedBeforeRead || Object.prototype.hasOwnProperty.call(response, responseReader))
+      (bodyUsedBeforeRead ||
+        bodyLockedBeforeRead ||
+        Object.prototype.hasOwnProperty.call(response, responseReader))
     ) {
       throw error;
     }
@@ -656,6 +661,7 @@ export abstract class APIClient {
     controller: AbortController,
   ): Promise<string> {
     const bodyUsedBeforeRead = response.bodyUsed;
+    const bodyLockedBeforeRead = (response.body as any)?.locked === true;
     const hasCustomTextReader = Object.prototype.hasOwnProperty.call(response, 'text');
     let deadlineExpired = false;
     let timeout: ReturnType<typeof setTimeout>;
@@ -675,7 +681,9 @@ export abstract class APIClient {
     } catch (error) {
       const cause = castToError(error);
       if (cause instanceof SDKRequestTimeoutError) throw cause;
-      if (cause.name === 'TypeError' && (bodyUsedBeforeRead || hasCustomTextReader)) throw error;
+      if (cause.name === 'TypeError' && (bodyUsedBeforeRead || bodyLockedBeforeRead || hasCustomTextReader)) {
+        throw error;
+      }
       throw deadlineExpired ? new SDKRequestTimeoutError(cause) : cause;
     } finally {
       clearTimeout(timeout!);

--- a/src/core.ts
+++ b/src/core.ts
@@ -539,6 +539,10 @@ export abstract class APIClient {
       } catch (error) {
         const cause = castToError(error);
         if (!isTransportError(cause)) throw error;
+        const normalized = normalizeTransportError(cause, attempts);
+        if (retriesRemaining && this.shouldRetryTransport(options, normalized.code, normalized.phase)) {
+          return this.retryRequest(options, retriesRemaining);
+        }
         throw APIConnectionError.fromCause(cause, attempts);
       }
       const errJSON = safeJSON(errText);
@@ -923,8 +927,8 @@ export type RequestOptions<
   httpAgent?: Agent;
   signal?: AbortSignal | undefined | null;
   idempotencyKey?: string;
-  /** Fetch redirect handling for this request. */
-  redirect?: 'error' | 'follow' | 'manual';
+  /** Reject redirect responses instead of forwarding request credentials. */
+  redirect?: 'error';
 
   __binaryRequest?: boolean | undefined;
   __binaryResponse?: boolean | undefined;

--- a/src/core.ts
+++ b/src/core.ts
@@ -62,6 +62,8 @@ export type APIResponseProps = {
 
 async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
   const { response } = props;
+  let responseReader: 'json' | 'text' | undefined;
+  let bodyUsedBeforeRead = false;
   try {
     if (props.options.stream) {
       debug('response', response.status, response.url, response.headers, response.body);
@@ -95,6 +97,8 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
         return undefined as T;
       }
 
+      responseReader = 'json';
+      bodyUsedBeforeRead = response.bodyUsed;
       const json = await response.json();
 
       debug('response', response.status, response.url, response.headers, json);
@@ -102,6 +106,8 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
       return json as T;
     }
 
+    responseReader = 'text';
+    bodyUsedBeforeRead = response.bodyUsed;
     const text = await response.text();
     debug('response', response.status, response.url, response.headers, text);
 
@@ -110,6 +116,13 @@ async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
   } catch (error) {
     if (error instanceof APIError) throw error;
     const cause = castToError(error);
+    if (
+      cause.name === 'TypeError' &&
+      responseReader &&
+      (bodyUsedBeforeRead || Object.prototype.hasOwnProperty.call(response, responseReader))
+    ) {
+      throw error;
+    }
     if (!isTransportError(cause)) throw error;
     throw APIConnectionError.fromCause(cause, props.attempts ?? 1);
   }
@@ -642,6 +655,8 @@ export abstract class APIClient {
     timeoutMs: number,
     controller: AbortController,
   ): Promise<string> {
+    const bodyUsedBeforeRead = response.bodyUsed;
+    const hasCustomTextReader = Object.prototype.hasOwnProperty.call(response, 'text');
     let deadlineExpired = false;
     let timeout: ReturnType<typeof setTimeout>;
     const deadline = new Promise<never>((_, reject) => {
@@ -660,6 +675,7 @@ export abstract class APIClient {
     } catch (error) {
       const cause = castToError(error);
       if (cause instanceof SDKRequestTimeoutError) throw cause;
+      if (cause.name === 'TypeError' && (bodyUsedBeforeRead || hasCustomTextReader)) throw error;
       throw deadlineExpired ? new SDKRequestTimeoutError(cause) : cause;
     } finally {
       clearTimeout(timeout!);

--- a/src/core.ts
+++ b/src/core.ts
@@ -388,6 +388,7 @@ export abstract class APIClient {
       ...(body && { body: body as any }),
       headers: reqHeaders,
       ...(httpAgent && { agent: httpAgent }),
+      ...(options.redirect && { redirect: options.redirect }),
       // @ts-ignore node-fetch uses a custom AbortSignal type that is
       // not compatible with standard web types
       signal: options.signal ?? null,
@@ -922,6 +923,8 @@ export type RequestOptions<
   httpAgent?: Agent;
   signal?: AbortSignal | undefined | null;
   idempotencyKey?: string;
+  /** Fetch redirect handling for this request. */
+  redirect?: 'error' | 'follow' | 'manual';
 
   __binaryRequest?: boolean | undefined;
   __binaryResponse?: boolean | undefined;
@@ -945,6 +948,7 @@ const requestOptionsKeys: KeysEnum<RequestOptions> = {
   httpAgent: true,
   signal: true,
   idempotencyKey: true,
+  redirect: true,
 
   __binaryRequest: true,
   __binaryResponse: true,

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,12 +1,6 @@
 import { VERSION } from './version';
 import { Stream } from './streaming';
-import {
-  RunloopError,
-  APIError,
-  APIConnectionError,
-  APIConnectionTimeoutError,
-  APIUserAbortError,
-} from './error';
+import { RunloopError, APIError, APIConnectionError, APIUserAbortError } from './error';
 import { stringifyQuery } from './internal/utils/query';
 import {
   kind as shimsKind,
@@ -26,6 +20,7 @@ init();
 
 export { type Response };
 import { BlobLike, isBlobLike, isMultipartBody } from './uploads';
+import { isTransportError, normalizeTransportError, SDKRequestTimeoutError } from './lib/error-normalization';
 export {
   maybeMultipartFormRequestOptions,
   multipartFormRequestOptions,
@@ -56,54 +51,62 @@ export type APIResponseProps = {
   response: Response;
   options: FinalRequestOptions;
   controller: AbortController;
+  attempts?: number;
 };
 
 async function defaultParseResponse<T>(props: APIResponseProps): Promise<T> {
   const { response } = props;
-  if (props.options.stream) {
-    debug('response', response.status, response.url, response.headers, response.body);
+  try {
+    if (props.options.stream) {
+      debug('response', response.status, response.url, response.headers, response.body);
 
-    // Note: there is an invariant here that isn't represented in the type system
-    // that if you set `stream: true` the response type must also be `Stream<T>`
+      // Note: there is an invariant here that isn't represented in the type system
+      // that if you set `stream: true` the response type must also be `Stream<T>`
 
-    if (props.options.__streamClass) {
-      return props.options.__streamClass.fromSSEResponse(response, props.controller) as any;
+      if (props.options.__streamClass) {
+        return props.options.__streamClass.fromSSEResponse(response, props.controller) as any;
+      }
+
+      return Stream.fromSSEResponse(response, props.controller) as any;
     }
 
-    return Stream.fromSSEResponse(response, props.controller) as any;
-  }
-
-  // fetch refuses to read the body when the status code is 204.
-  if (response.status === 204) {
-    return null as T;
-  }
-
-  if (props.options.__binaryResponse) {
-    return response as unknown as T;
-  }
-
-  const contentType = response.headers.get('content-type');
-  const mediaType = contentType?.split(';')[0]?.trim();
-  const isJSON = mediaType?.includes('application/json') || mediaType?.endsWith('+json');
-  if (isJSON) {
-    const contentLength = response.headers.get('content-length');
-    if (contentLength === '0') {
-      // if there is no content we can't do anything
-      return undefined as T;
+    // fetch refuses to read the body when the status code is 204.
+    if (response.status === 204) {
+      return null as T;
     }
 
-    const json = await response.json();
+    if (props.options.__binaryResponse) {
+      return response as unknown as T;
+    }
 
-    debug('response', response.status, response.url, response.headers, json);
+    const contentType = response.headers.get('content-type');
+    const mediaType = contentType?.split(';')[0]?.trim();
+    const isJSON = mediaType?.includes('application/json') || mediaType?.endsWith('+json');
+    if (isJSON) {
+      const contentLength = response.headers.get('content-length');
+      if (contentLength === '0') {
+        // if there is no content we can't do anything
+        return undefined as T;
+      }
 
-    return json as T;
+      const json = await response.json();
+
+      debug('response', response.status, response.url, response.headers, json);
+
+      return json as T;
+    }
+
+    const text = await response.text();
+    debug('response', response.status, response.url, response.headers, text);
+
+    // TODO handle blob, arraybuffer, other content types, etc.
+    return text as unknown as T;
+  } catch (error) {
+    if (error instanceof APIError) throw error;
+    const cause = castToError(error);
+    if (!isTransportError(cause)) throw error;
+    throw APIConnectionError.fromCause(cause, props.attempts ?? 1);
   }
-
-  const text = await response.text();
-  debug('response', response.status, response.url, response.headers, text);
-
-  // TODO handle blob, arraybuffer, other content types, etc.
-  return text as unknown as T;
 }
 
 /**
@@ -464,8 +467,9 @@ export abstract class APIClient {
     error: Object | undefined,
     message: string | undefined,
     headers: Headers | undefined,
+    attempts = 1,
   ): APIError {
-    return APIError.generate(status, error, message, headers);
+    return APIError.generate(status, error, message, headers, attempts);
   }
 
   request<Req, Rsp>(
@@ -501,41 +505,51 @@ export abstract class APIClient {
 
     const controller = new AbortController();
     const response = await this.fetchWithTimeout(url, req, timeout, controller).catch(castToError);
+    const attempts = maxRetries - retriesRemaining + 1;
 
     if (response instanceof Error) {
       if (options.signal?.aborted) {
         throw new APIUserAbortError();
       }
-      if (retriesRemaining) {
+      const normalized = normalizeTransportError(response, attempts);
+      if (retriesRemaining && this.shouldRetryTransport(options, normalized.code, normalized.phase)) {
         return this.retryRequest(options, retriesRemaining);
       }
-      if (response.name === 'AbortError') {
-        throw new APIConnectionTimeoutError();
-      }
-      throw new APIConnectionError({ cause: response });
+      throw APIConnectionError.fromCause(response, attempts);
     }
 
     const responseHeaders = createResponseHeaders(response.headers);
 
     if (!response.ok) {
-      if (retriesRemaining && this.shouldRetry(response)) {
+      let errText: string;
+      try {
+        errText = await response.text();
+      } catch (error) {
+        const cause = castToError(error);
+        if (!isTransportError(cause)) throw error;
+        throw APIConnectionError.fromCause(cause, attempts);
+      }
+      const errJSON = safeJSON(errText);
+      const errMessage = errJSON ? undefined : errText;
+      const responseCode =
+        responseHeaders['x-runloop-error-code'] ||
+        (errJSON && typeof (errJSON as any).error === 'string' ? (errJSON as any).error : undefined);
+
+      if (retriesRemaining && this.shouldRetry(response, options, responseCode)) {
         const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
         debug(`response (error; ${retryMessage})`, response.status, url, responseHeaders);
         return this.retryRequest(options, retriesRemaining, responseHeaders);
       }
 
-      const errText = await response.text().catch((e) => castToError(e).message);
-      const errJSON = safeJSON(errText);
-      const errMessage = errJSON ? undefined : errText;
       const retryMessage = retriesRemaining ? `(error; no more retries left)` : `(error; not retryable)`;
 
       debug(`response (error; ${retryMessage})`, response.status, url, responseHeaders, errMessage);
 
-      const err = this.makeStatusError(response.status, errJSON, errMessage, responseHeaders);
+      const err = this.makeStatusError(response.status, errJSON, errMessage, responseHeaders, attempts);
       throw err;
     }
 
-    return { response, options, controller };
+    return { response, options, controller, attempts };
   }
 
   requestAPIList<Item = unknown, PageClass extends AbstractPage<Item> = AbstractPage<Item>>(
@@ -579,7 +593,11 @@ export abstract class APIClient {
     const { signal, ...options } = init || {};
     if (signal) signal.addEventListener('abort', () => controller.abort());
 
-    const timeout = setTimeout(() => controller.abort(), ms);
+    let deadlineExpired = false;
+    const timeout = setTimeout(() => {
+      deadlineExpired = true;
+      controller.abort();
+    }, ms);
 
     const fetchOptions = {
       signal: controller.signal as any,
@@ -593,13 +611,34 @@ export abstract class APIClient {
 
     return (
       // use undefined this binding; fetch errors if bound to something else in browser/cloudflare
-      this.fetch.call(undefined, url, fetchOptions).finally(() => {
-        clearTimeout(timeout);
-      })
+      this.fetch
+        .call(undefined, url, fetchOptions)
+        .catch((error) => {
+          const cause = castToError(error);
+          throw deadlineExpired ? new SDKRequestTimeoutError(cause) : cause;
+        })
+        .finally(() => {
+          clearTimeout(timeout);
+        })
     );
   }
 
-  private shouldRetry(response: Response): boolean {
+  private isRetrySafe(options: FinalRequestOptions): boolean {
+    if (isMultipartBody(options.body)) return false;
+    const path = options.path ?? '';
+    // Execution requests can reach the server before a transport failure is observed.
+    if (/\/(execute|execute_async|wait_for_status)(?:\/|$)/.test(path)) return false;
+    if (['get', 'head', 'options', 'put', 'delete'].includes(options.method)) return true;
+    return Boolean(options.idempotencyKey);
+  }
+
+  private shouldRetryTransport(options: FinalRequestOptions, code?: string, phase?: string): boolean {
+    if (!this.isRetrySafe(options)) return false;
+    return code === 'request_timeout' || code === 'connection_timeout' || phase === 'connect';
+  }
+
+  private shouldRetry(response: Response, options: FinalRequestOptions, code?: string): boolean {
+    if (!this.isRetrySafe(options)) return false;
     // Note this is not a standard header.
     const shouldRetryHeader = response.headers.get('x-should-retry');
 
@@ -617,7 +656,13 @@ export abstract class APIClient {
     if (response.status === 429) return true;
 
     // Retry internal errors.
-    if (response.status >= 500) return true;
+    if (response.status >= 500) {
+      return ![
+        'upload_request_body_idle_timeout',
+        'tunnel_backend_idle_timeout',
+        'tunnel_backend_connection_reset',
+      ].includes(code ?? '');
+    }
 
     return false;
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -20,7 +20,13 @@ init();
 
 export { type Response };
 import { BlobLike, isBlobLike, isMultipartBody } from './uploads';
-import { isTransportError, normalizeTransportError, SDKRequestTimeoutError } from './lib/error-normalization';
+import {
+  isTransportError,
+  normalizeResponseError,
+  normalizeTransportError,
+  type RunloopErrorDetails,
+  SDKRequestTimeoutError,
+} from './lib/error-normalization';
 export {
   maybeMultipartFormRequestOptions,
   multipartFormRequestOptions,
@@ -503,6 +509,7 @@ export abstract class APIClient {
       throw new APIUserAbortError();
     }
 
+    const attemptStartedAt = Date.now();
     const controller = new AbortController();
     const response = await this.fetchWithTimeout(url, req, timeout, controller).catch(castToError);
     const attempts = maxRetries - retriesRemaining + 1;
@@ -523,7 +530,11 @@ export abstract class APIClient {
     if (!response.ok) {
       let errText: string;
       try {
-        errText = await response.text();
+        errText = await this.readErrorResponseText(
+          response,
+          Math.max(1, timeout - (Date.now() - attemptStartedAt)),
+          controller,
+        );
       } catch (error) {
         const cause = castToError(error);
         if (!isTransportError(cause)) throw error;
@@ -531,11 +542,9 @@ export abstract class APIClient {
       }
       const errJSON = safeJSON(errText);
       const errMessage = errJSON ? undefined : errText;
-      const responseCode =
-        responseHeaders['x-runloop-error-code'] ||
-        (errJSON && typeof (errJSON as any).error === 'string' ? (errJSON as any).error : undefined);
+      const details = normalizeResponseError(errJSON, responseHeaders, attempts);
 
-      if (retriesRemaining && this.shouldRetry(response, options, responseCode)) {
+      if (retriesRemaining && this.shouldRetry(response, options, details)) {
         const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
         debug(`response (error; ${retryMessage})`, response.status, url, responseHeaders);
         return this.retryRequest(options, retriesRemaining, responseHeaders);
@@ -623,6 +632,35 @@ export abstract class APIClient {
     );
   }
 
+  private async readErrorResponseText(
+    response: Response,
+    timeoutMs: number,
+    controller: AbortController,
+  ): Promise<string> {
+    let deadlineExpired = false;
+    let timeout: ReturnType<typeof setTimeout>;
+    const deadline = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        deadlineExpired = true;
+        controller.abort();
+        reject(
+          new SDKRequestTimeoutError(
+            Object.assign(new Error('Response body read timed out.'), { name: 'AbortError' }),
+          ),
+        );
+      }, timeoutMs);
+    });
+    try {
+      return await Promise.race([response.text(), deadline]);
+    } catch (error) {
+      const cause = castToError(error);
+      if (cause instanceof SDKRequestTimeoutError) throw cause;
+      throw deadlineExpired ? new SDKRequestTimeoutError(cause) : cause;
+    } finally {
+      clearTimeout(timeout!);
+    }
+  }
+
   private isRetrySafe(options: FinalRequestOptions): boolean {
     if (isMultipartBody(options.body)) return false;
     const path = options.path ?? '';
@@ -637,14 +675,21 @@ export abstract class APIClient {
     return code === 'request_timeout' || code === 'connection_timeout' || phase === 'connect';
   }
 
-  private shouldRetry(response: Response, options: FinalRequestOptions, code?: string): boolean {
+  private shouldRetry(
+    response: Response,
+    options: FinalRequestOptions,
+    details: RunloopErrorDetails,
+  ): boolean {
     if (!this.isRetrySafe(options)) return false;
+    if (details.code === 'tunnel_unavailable') return false;
     // Note this is not a standard header.
     const shouldRetryHeader = response.headers.get('x-should-retry');
 
     // If the server explicitly says whether or not to retry, obey.
     if (shouldRetryHeader === 'true') return true;
     if (shouldRetryHeader === 'false') return false;
+    if (details.retryable === false) return false;
+    if (details.retryable === true) return true;
 
     // Retry on request timeouts.
     if (response.status === 408) return true;
@@ -661,7 +706,7 @@ export abstract class APIClient {
         'upload_request_body_idle_timeout',
         'tunnel_backend_idle_timeout',
         'tunnel_backend_connection_reset',
-      ].includes(code ?? '');
+      ].includes(details.code ?? '');
     }
 
     return false;

--- a/src/core.ts
+++ b/src/core.ts
@@ -927,8 +927,8 @@ export type RequestOptions<
   httpAgent?: Agent;
   signal?: AbortSignal | undefined | null;
   idempotencyKey?: string;
-  /** Reject redirect responses instead of forwarding request credentials. */
-  redirect?: 'error';
+  /** Return redirect responses without following their Location. */
+  redirect?: 'manual';
 
   __binaryRequest?: boolean | undefined;
   __binaryResponse?: boolean | undefined;

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,11 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import { castToError, Headers } from './core';
+import {
+  type RunloopErrorDetails,
+  normalizeResponseError,
+  normalizeTransportError,
+} from './lib/error-normalization';
 
 export class RunloopError extends Error {}
 
@@ -15,12 +20,32 @@ export class APIError<
   readonly headers: THeaders;
   /** JSON body of the response that caused the error */
   readonly error: TError;
+  readonly code: string | undefined;
+  readonly phase: string | undefined;
+  readonly retryable: boolean | undefined;
+  readonly requestID: string | undefined;
+  readonly retryAfter: number | undefined;
+  readonly attempts: number | undefined;
+  declare readonly cause: Error | undefined;
 
-  constructor(status: TStatus, error: TError, message: string | undefined, headers: THeaders) {
+  constructor(
+    status: TStatus,
+    error: TError,
+    message: string | undefined,
+    headers: THeaders,
+    details: RunloopErrorDetails = {},
+  ) {
     super(`${APIError.makeMessage(status, error, message)}`);
     this.status = status;
     this.headers = headers;
     this.error = error;
+    this.code = details.code;
+    this.phase = details.phase;
+    this.retryable = details.retryable;
+    this.requestID = details.requestID;
+    this.retryAfter = details.retryAfter;
+    this.attempts = details.attempts;
+    if (details.cause) Object.defineProperty(this, 'cause', { value: details.cause, enumerable: false });
   }
 
   private static makeMessage(status: number | undefined, error: any, message: string | undefined) {
@@ -29,6 +54,7 @@ export class APIError<
         typeof error.message === 'string' ?
           error.message
         : JSON.stringify(error.message)
+      : typeof error?.error === 'string' ? error.error
       : error ? JSON.stringify(error)
       : message;
 
@@ -49,46 +75,49 @@ export class APIError<
     errorResponse: Object | undefined,
     message: string | undefined,
     headers: Headers | undefined,
+    attempts = 1,
   ): APIError {
     if (!status || !headers) {
-      return new APIConnectionError({ message, cause: castToError(errorResponse) });
+      const cause = castToError(errorResponse);
+      return APIConnectionError.fromCause(cause, attempts, message);
     }
 
     const error = errorResponse as Record<string, any>;
+    const details = normalizeResponseError(error, headers, attempts);
 
     if (status === 400) {
-      return new BadRequestError(status, error, message, headers);
+      return new BadRequestError(status, error, message, headers, details);
     }
 
     if (status === 401) {
-      return new AuthenticationError(status, error, message, headers);
+      return new AuthenticationError(status, error, message, headers, details);
     }
 
     if (status === 403) {
-      return new PermissionDeniedError(status, error, message, headers);
+      return new PermissionDeniedError(status, error, message, headers, details);
     }
 
     if (status === 404) {
-      return new NotFoundError(status, error, message, headers);
+      return new NotFoundError(status, error, message, headers, details);
     }
 
     if (status === 409) {
-      return new ConflictError(status, error, message, headers);
+      return new ConflictError(status, error, message, headers, details);
     }
 
     if (status === 422) {
-      return new UnprocessableEntityError(status, error, message, headers);
+      return new UnprocessableEntityError(status, error, message, headers, details);
     }
 
     if (status === 429) {
-      return new RateLimitError(status, error, message, headers);
+      return new RateLimitError(status, error, message, headers, details);
     }
 
     if (status >= 500) {
-      return new InternalServerError(status, error, message, headers);
+      return new InternalServerError(status, error, message, headers, details);
     }
 
-    return new APIError(status, error, message, headers);
+    return new APIError(status, error, message, headers, details);
   }
 }
 
@@ -99,17 +128,41 @@ export class APIUserAbortError extends APIError<undefined, undefined, undefined>
 }
 
 export class APIConnectionError extends APIError<undefined, undefined, undefined> {
-  constructor({ message, cause }: { message?: string | undefined; cause?: Error | undefined }) {
-    super(undefined, undefined, message || 'Connection error.', undefined);
-    // in some environments the 'cause' property is already declared
-    // @ts-ignore
-    if (cause) this.cause = cause;
+  constructor({
+    message,
+    cause,
+    details,
+  }: {
+    message?: string | undefined;
+    cause?: Error | undefined;
+    details?: RunloopErrorDetails | undefined;
+  }) {
+    super(undefined, undefined, message || 'Connection error.', undefined, {
+      ...details,
+      ...(cause ? { cause } : {}),
+    });
+  }
+
+  static fromCause(cause: Error, attempts = 1, message?: string | undefined): APIConnectionError {
+    const details = normalizeTransportError(cause, attempts);
+    if (details.code === 'request_timeout' || details.code === 'connection_timeout') {
+      return new APIConnectionTimeoutError({ message, details });
+    }
+    return new APIConnectionError({ message, details });
   }
 }
 
 export class APIConnectionTimeoutError extends APIConnectionError {
-  constructor({ message }: { message?: string } = {}) {
-    super({ message: message ?? 'Request timed out.' });
+  constructor({
+    message,
+    cause,
+    details,
+  }: {
+    message?: string | undefined;
+    cause?: Error | undefined;
+    details?: RunloopErrorDetails | undefined;
+  } = {}) {
+    super({ message: message ?? 'Request timed out.', cause, details });
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -842,6 +842,8 @@ export declare namespace Runloop {
 }
 
 export { type LongPollRequestOptions, LongPollAbortError, PollingTimeoutError } from './lib/polling';
+export { type TunnelReadinessOptions } from './lib/tunnel-readiness';
+export { type RunloopErrorDetails } from './lib/error-normalization';
 export { toFile, fileFromPath } from './uploads';
 export {
   RunloopError,

--- a/src/lib/error-normalization.ts
+++ b/src/lib/error-normalization.ts
@@ -1,0 +1,143 @@
+/** Stable, transport-independent details attached to public SDK errors. */
+export interface RunloopErrorDetails {
+  code?: string | undefined;
+  phase?: string | undefined;
+  retryable?: boolean | undefined;
+  requestID?: string | undefined;
+  /** Server requested retry delay, in seconds. */
+  retryAfter?: number | undefined;
+  attempts?: number | undefined;
+  cause?: Error | undefined;
+}
+
+type ErrorLike = Error & { code?: unknown; cause?: unknown; opaqueData?: unknown; debugData?: unknown };
+
+/** Marks an AbortError produced by the SDK's own request deadline. */
+export class SDKRequestTimeoutError extends Error {
+  readonly code = 'RUNLOOP_REQUEST_TIMEOUT';
+
+  constructor(readonly cause: Error) {
+    super(cause.message || 'Request timed out.');
+    this.name = 'AbortError';
+  }
+}
+
+function errorChain(error: Error): ErrorLike[] {
+  const chain: ErrorLike[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    chain.push(current as ErrorLike);
+    current = (current as ErrorLike).cause;
+  }
+  return chain;
+}
+
+/** Whether an error originated in a fetch/HTTP transport rather than response parsing or user code. */
+export function isTransportError(error: Error): boolean {
+  const chain = errorChain(error);
+  if (chain.some((item) => typeof item.code === 'string')) return true;
+  if (chain.some((item) => item.name === 'AbortError' || item.name === 'TypeError')) return true;
+  return chain.some((item) => /http\/2|protocol error/i.test(item.message));
+}
+
+function stringData(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Uint8Array) return new TextDecoder().decode(value);
+  return '';
+}
+
+/** Normalize native fetch, Undici, node:http2, and custom transport failures. */
+export function normalizeTransportError(error: Error, attempts: number): RunloopErrorDetails {
+  const chain = errorChain(error);
+  const codes = chain.map((item) => (typeof item.code === 'string' ? item.code : undefined));
+  const text = chain
+    .map((item) => `${item.message} ${stringData(item.opaqueData)} ${stringData(item.debugData)}`)
+    .join(' ')
+    .toLowerCase();
+
+  let code = 'connection_error';
+  let phase = 'transport';
+  let retryable = false;
+
+  if (error instanceof SDKRequestTimeoutError) {
+    code = 'request_timeout';
+    phase = 'request';
+    retryable = true;
+  } else if (codes.includes('UND_ERR_CONNECT_TIMEOUT')) {
+    code = 'connection_timeout';
+    phase = 'connect';
+    retryable = true;
+  } else if (codes.includes('UND_ERR_HEADERS_TIMEOUT')) {
+    code = 'response_headers_timeout';
+    phase = 'response_headers';
+  } else if (codes.includes('UND_ERR_BODY_TIMEOUT')) {
+    code = 'response_read_timeout';
+    phase = 'response_read';
+  } else if (codes.includes('ERR_HTTP2_GOAWAY_SESSION') && text.includes('idle_timeout')) {
+    code = 'http2_idle_timeout';
+    phase = 'response_read';
+  } else if (codes.includes('ECONNRESET')) {
+    code = 'connection_reset';
+  } else if (
+    codes.some((value) => value?.startsWith('ERR_HTTP2_')) ||
+    text.includes('http/2') ||
+    text.includes('protocol error')
+  ) {
+    code = 'http2_protocol_error';
+  } else if (
+    codes.includes('ECONNREFUSED') ||
+    codes.includes('ENETUNREACH') ||
+    codes.includes('EHOSTUNREACH')
+  ) {
+    phase = 'connect';
+    retryable = true;
+  }
+
+  return {
+    code,
+    phase,
+    retryable,
+    attempts,
+    cause: error instanceof SDKRequestTimeoutError ? error.cause : error,
+  };
+}
+
+export function parseRetryAfter(headers: Record<string, string | null | undefined>): number | undefined {
+  const milliseconds = headers['retry-after-ms'];
+  if (milliseconds) {
+    const parsed = Number.parseFloat(milliseconds);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed / 1000;
+  }
+
+  const value = headers['retry-after'];
+  if (!value) return undefined;
+  const seconds = Number.parseFloat(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds;
+  const date = Date.parse(value);
+  return Number.isNaN(date) ? undefined : Math.max(0, (date - Date.now()) / 1000);
+}
+
+/** Extract details from the backwards-compatible Runloop JSON error envelope. */
+export function normalizeResponseError(
+  body: unknown,
+  headers: Record<string, string | null | undefined>,
+  attempts: number,
+): RunloopErrorDetails {
+  const envelope = body && typeof body === 'object' ? (body as Record<string, unknown>) : undefined;
+  const headerCode = headers['x-runloop-error-code'];
+  const headerRequestID = headers['x-runloop-request-id'];
+  return {
+    code:
+      headerCode ||
+      (typeof envelope?.['error'] === 'string' ? envelope['error'] : undefined) ||
+      (typeof envelope?.['code'] === 'string' ? envelope['code'] : undefined),
+    phase: typeof envelope?.['phase'] === 'string' ? envelope['phase'] : undefined,
+    retryable: typeof envelope?.['retryable'] === 'boolean' ? envelope['retryable'] : undefined,
+    requestID:
+      headerRequestID || (typeof envelope?.['request_id'] === 'string' ? envelope['request_id'] : undefined),
+    retryAfter: parseRetryAfter(headers),
+    attempts,
+  };
+}

--- a/src/lib/error-normalization.ts
+++ b/src/lib/error-normalization.ts
@@ -37,7 +37,16 @@ function errorChain(error: Error): ErrorLike[] {
 /** Whether an error originated in a fetch/HTTP transport rather than response parsing or user code. */
 export function isTransportError(error: Error): boolean {
   const chain = errorChain(error);
-  if (chain.some((item) => typeof item.code === 'string')) return true;
+  if (
+    chain.some(
+      (item) =>
+        typeof item.code === 'string' &&
+        (/^(?:UND_ERR_|ERR_HTTP2_)/.test(item.code) ||
+          /^(?:ECONN|ENET|EHOST|EPIPE|ETIMEDOUT|EPROTO|ESOCKET|EAI_)/.test(item.code)),
+    )
+  ) {
+    return true;
+  }
   if (chain.some((item) => item.name === 'AbortError' || item.name === 'TypeError')) return true;
   return chain.some((item) => /http\/2|protocol error/i.test(item.message));
 }

--- a/src/lib/error-normalization.ts
+++ b/src/lib/error-normalization.ts
@@ -47,11 +47,10 @@ export function isTransportError(error: Error): boolean {
   ) {
     return true;
   }
-  // Native fetch commonly rejects with a top-level TypeError, but its transport
-  // cause carries one of the codes above. Treating every TypeError as transport
-  // would also mask ordinary response parser failures (for example, reading an
-  // already-consumed body), so require transport-specific evidence instead.
-  if (chain.some((item) => item.name === 'AbortError')) return true;
+  // Browser fetch implementations can report response-body network failures as
+  // a bare TypeError. Callers that know the TypeError came from parser misuse
+  // must exclude that case before using this transport-level predicate.
+  if (chain.some((item) => item.name === 'AbortError' || item.name === 'TypeError')) return true;
   return chain.some((item) => /http\/2|protocol error/i.test(item.message));
 }
 

--- a/src/lib/error-normalization.ts
+++ b/src/lib/error-normalization.ts
@@ -47,7 +47,11 @@ export function isTransportError(error: Error): boolean {
   ) {
     return true;
   }
-  if (chain.some((item) => item.name === 'AbortError' || item.name === 'TypeError')) return true;
+  // Native fetch commonly rejects with a top-level TypeError, but its transport
+  // cause carries one of the codes above. Treating every TypeError as transport
+  // would also mask ordinary response parser failures (for example, reading an
+  // already-consumed body), so require transport-specific evidence instead.
+  if (chain.some((item) => item.name === 'AbortError')) return true;
   return chain.some((item) => /http\/2|protocol error/i.test(item.message));
 }
 

--- a/src/lib/error-normalization.ts
+++ b/src/lib/error-normalization.ts
@@ -50,7 +50,7 @@ export function isTransportError(error: Error): boolean {
   // Browser fetch implementations can report response-body network failures as
   // a bare TypeError. Callers that know the TypeError came from parser misuse
   // must exclude that case before using this transport-level predicate.
-  if (chain.some((item) => item.name === 'AbortError' || item.name === 'TypeError')) return true;
+  if (chain.some((item) => item.name === 'AbortError') || error.name === 'TypeError') return true;
   return chain.some((item) => /http\/2|protocol error/i.test(item.message));
 }
 

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -135,7 +135,6 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
       signal,
       method = 'GET',
       headers: rawHeaders,
-      redirect,
     } = (init ?? {}) as any;
 
     const parsed = typeof url === 'string' ? new URL(url) : new URL(url.toString());
@@ -157,10 +156,6 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
 
     const pool = getPool(parsed.origin);
     const h2resp = await pool.request(path, method.toUpperCase(), reqHeaders, body, signal);
-    if (redirect === 'error' && h2resp.status >= 300 && h2resp.status < 400) {
-      await h2resp.body.cancel();
-      throw new TypeError(`Redirect response (${h2resp.status}) is not allowed`);
-    }
     return toFetchResponse(h2resp) as any;
   }) as H2Fetch;
 

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -42,6 +42,7 @@ function checkNodeVersion(): void {
 }
 
 export type { H2PoolOptions as H2FetchOptions };
+export { H2GoawayError } from './session';
 
 export type H2Fetch = Fetch & {
   close: () => Promise<void>;

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -82,7 +82,25 @@ function toFetchResponse(h2: H2Response): Response {
   for (const [key, value] of h2.headers.entries()) headers[key] = value;
 
   const body = NULL_BODY_STATUSES.has(h2.status) ? null : Readable.fromWeb(h2.body as any);
+  let bodyError: Error | undefined;
+  body?.once('error', (error) => {
+    bodyError = error;
+  });
   const response = new Response(body as any, { status: h2.status, headers });
+
+  // node-fetch wraps stream failures in a new FetchError and drops the
+  // original exception. Restore it for SDK parsing so GOAWAY metadata and
+  // other low-level transport details remain available as APIError.cause.
+  for (const method of ['json', 'text'] as const) {
+    const consume = response[method].bind(response);
+    (response as any)[method] = async () => {
+      try {
+        return await consume();
+      } catch (error) {
+        throw bodyError ?? error;
+      }
+    };
+  }
 
   // node-fetch derives `url` from the request internals it never saw; expose the
   // real request URL (`Response.url` is a prototype getter, shadowed here).

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -91,8 +91,9 @@ function toFetchResponse(h2: H2Response): Response {
   // node-fetch wraps stream failures in a new FetchError and drops the
   // original exception. Restore it for SDK parsing so GOAWAY metadata and
   // other low-level transport details remain available as APIError.cause.
-  for (const method of ['json', 'text'] as const) {
-    const consume = response[method].bind(response);
+  for (const method of ['arrayBuffer', 'blob', 'buffer', 'json', 'text'] as const) {
+    const consume = (response as any)[method]?.bind(response);
+    if (!consume) continue;
     (response as any)[method] = async () => {
       try {
         return await consume();
@@ -134,6 +135,7 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
       signal,
       method = 'GET',
       headers: rawHeaders,
+      redirect,
     } = (init ?? {}) as any;
 
     const parsed = typeof url === 'string' ? new URL(url) : new URL(url.toString());
@@ -155,6 +157,10 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
 
     const pool = getPool(parsed.origin);
     const h2resp = await pool.request(path, method.toUpperCase(), reqHeaders, body, signal);
+    if (redirect === 'error' && h2resp.status >= 300 && h2resp.status < 400) {
+      await h2resp.body.cancel();
+      throw new TypeError(`Redirect response (${h2resp.status}) is not allowed`);
+    }
     return toFetchResponse(h2resp) as any;
   }) as H2Fetch;
 

--- a/src/lib/h2-transport/index.ts
+++ b/src/lib/h2-transport/index.ts
@@ -153,6 +153,10 @@ export function createH2Fetch(options?: H2PoolOptions): H2Fetch {
         }
       }
     }
+    // Unlike HTTP/1 fetch implementations, node:http2 does not expose an
+    // ordinary Host header to every downstream adapter from :authority. Send
+    // it explicitly for gateways/backends that validate the HTTP header map.
+    reqHeaders['host'] = parsed.host;
 
     const pool = getPool(parsed.origin);
     const h2resp = await pool.request(path, method.toUpperCase(), reqHeaders, body, signal);

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -219,7 +219,9 @@ export class H2Pool {
     signal?: AbortSignal | null,
     allowGoawayRetry = true,
   ): Promise<H2Response> {
+    if (this._closed) throw new Error('Pool is closed');
     await this._initialize();
+    if (this._closed) throw new Error('Pool is closed');
 
     // After init, try the fast path before queuing
     const session = this._findAvailable();
@@ -228,6 +230,10 @@ export class H2Pool {
     }
 
     return new Promise<H2Response>((resolve, reject) => {
+      if (this._closed) {
+        reject(new Error('Pool is closed'));
+        return;
+      }
       this._queue.push({ path, method, headers, body, signal, allowGoawayRetry, resolve, reject });
 
       if (!this._growing && this._sessions.length < this._maxConnections) {

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -16,6 +16,7 @@ interface QueuedRequest {
   headers: Record<string, string>;
   body: string | Buffer | null;
   signal: AbortSignal | null | undefined;
+  allowGoawayRetry: boolean;
   resolve: (response: H2Response) => void;
   reject: (error: Error) => void;
 }
@@ -103,10 +104,15 @@ export class H2Pool {
       const session = this._findAvailable();
       if (!session) break;
       const req = this._queue.shift()!;
-      this._dispatchToSession(session, req.path, req.method, req.headers, req.body, req.signal).then(
-        req.resolve,
-        req.reject,
-      );
+      this._dispatchToSession(
+        session,
+        req.path,
+        req.method,
+        req.headers,
+        req.body,
+        req.signal,
+        req.allowGoawayRetry,
+      ).then(req.resolve, req.reject);
     }
 
     if (this._queue.length > 0 && !this._growing) {
@@ -138,13 +144,19 @@ export class H2Pool {
     headers: Record<string, string>,
     body: string | Buffer | null,
     signal?: AbortSignal | null,
+    allowGoawayRetry = true,
   ): Promise<H2Response> {
     try {
       return await session.request(path, method, headers, body, signal);
     } catch (err: any) {
-      if (session.state !== SessionState.READY && RETRYABLE_METHODS.has(method)) {
+      if (
+        allowGoawayRetry &&
+        session.state !== SessionState.READY &&
+        RETRYABLE_METHODS.has(method) &&
+        err?.code !== 'ERR_HTTP2_GOAWAY_SESSION'
+      ) {
         // Session went away (GOAWAY, etc). Re-enter the pool for a retry.
-        return this._enqueueRequest(path, method, headers, body, signal);
+        return this._enqueueRequest(path, method, headers, body, signal, false);
       }
       throw err;
     }
@@ -205,17 +217,18 @@ export class H2Pool {
     headers: Record<string, string>,
     body: string | Buffer | null,
     signal?: AbortSignal | null,
+    allowGoawayRetry = true,
   ): Promise<H2Response> {
     await this._initialize();
 
     // After init, try the fast path before queuing
     const session = this._findAvailable();
     if (session) {
-      return this._dispatchToSession(session, path, method, headers, body, signal);
+      return this._dispatchToSession(session, path, method, headers, body, signal, allowGoawayRetry);
     }
 
     return new Promise<H2Response>((resolve, reject) => {
-      this._queue.push({ path, method, headers, body, signal, resolve, reject });
+      this._queue.push({ path, method, headers, body, signal, allowGoawayRetry, resolve, reject });
 
       if (!this._growing && this._sessions.length < this._maxConnections) {
         this._growPool();

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -88,6 +88,10 @@ export class H2Pool {
     };
 
     await session.connect();
+    if (this._closed) {
+      await session.close();
+      throw new Error('Pool is closed');
+    }
     this._sessions.push(session);
     return session;
   }

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -1,4 +1,4 @@
-import { H2Session, SessionState, type H2SessionOptions } from './session';
+import { H2GoawayError, H2Session, SessionState, type H2SessionOptions } from './session';
 import type { H2Response } from './response';
 
 export interface H2PoolOptions extends H2SessionOptions {
@@ -153,7 +153,7 @@ export class H2Pool {
         allowGoawayRetry &&
         session.state !== SessionState.READY &&
         RETRYABLE_METHODS.has(method) &&
-        err?.code !== 'ERR_HTTP2_GOAWAY_SESSION'
+        (!(err instanceof H2GoawayError) || err.unprocessed)
       ) {
         // Session went away (GOAWAY, etc). Re-enter the pool for a retry.
         return this._enqueueRequest(path, method, headers, body, signal, false);

--- a/src/lib/h2-transport/pool.ts
+++ b/src/lib/h2-transport/pool.ts
@@ -25,6 +25,7 @@ export class H2Pool {
   private readonly _origin: string;
   private readonly _opts: H2PoolOptions;
   private readonly _sessions: H2Session[] = [];
+  private readonly _connectingSessions = new Set<H2Session>();
   private readonly _queue: QueuedRequest[] = [];
   private _initialized = false;
   private _initPromise: Promise<void> | null = null;
@@ -74,7 +75,9 @@ export class H2Pool {
   }
 
   private async _addSession(): Promise<H2Session> {
+    if (this._closed) throw new Error('Pool is closed');
     const session = new H2Session(this._origin, this._opts);
+    this._connectingSessions.add(session);
 
     session.onAvailable = () => this._drainQueue();
 
@@ -87,7 +90,11 @@ export class H2Pool {
       }
     };
 
-    await session.connect();
+    try {
+      await session.connect();
+    } finally {
+      this._connectingSessions.delete(session);
+    }
     if (this._closed) {
       await session.close();
       throw new Error('Pool is closed');
@@ -248,7 +255,7 @@ export class H2Pool {
 
   async close(): Promise<void> {
     this._closed = true;
-    const sessions = [...this._sessions];
+    const sessions = [...new Set([...this._sessions, ...this._connectingSessions])];
     this._sessions.length = 0;
 
     for (const req of this._queue) {

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -126,11 +126,12 @@ export class H2Session {
 
       session.on('goaway', (errorCode, lastStreamID, opaqueData) => {
         this._state = SessionState.DRAINING;
-        for (const handler of [...this._goawayHandlers]) {
-          handler(errorCode, lastStreamID, opaqueData);
-        }
         if (this._activeStreams === 0) {
           this._close();
+          return;
+        }
+        for (const handler of [...this._goawayHandlers]) {
+          handler(errorCode, lastStreamID, opaqueData);
         }
       });
 

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -329,6 +329,10 @@ export class H2Session {
 
     return new Promise((resolve) => {
       session.once('close', resolve);
+      if (this._state === SessionState.CONNECTING) {
+        session.destroy(new Error('H2 session closed while connecting'));
+        return;
+      }
       this._close();
     });
   }

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -177,6 +177,7 @@ export class H2Session {
       let settled = false;
       let cleaned = false;
       let goawayCause: H2GoawayError | undefined;
+      let responseController: ReadableStreamDefaultController<Uint8Array> | undefined;
 
       const onAbort = () => {
         if (!cleaned) {
@@ -220,6 +221,17 @@ export class H2Session {
                 code: 'ERR_HTTP2_STREAM_ERROR',
               }),
           );
+        } else if (!cleaned) {
+          try {
+            responseController?.error(
+              goawayCause ??
+                Object.assign(new Error('HTTP/2 stream closed before the response body completed.'), {
+                  code: 'ERR_HTTP2_STREAM_ERROR',
+                }),
+            );
+          } catch {
+            // The response body may already have been closed/cancelled.
+          }
         }
         cleanup();
       });
@@ -251,10 +263,15 @@ export class H2Session {
         settled = true;
         const status = responseHeaders[':status'] as number;
         const h2headers = new H2Headers(responseHeaders);
+        const contentLength = Number(responseHeaders['content-length']);
+        const expectedBodyBytes = Number.isFinite(contentLength) ? contentLength : undefined;
+        let receivedBodyBytes = 0;
 
         const responseBody = new ReadableStream<Uint8Array>({
           start(controller) {
+            responseController = controller;
             stream.on('data', (chunk: Buffer) => {
+              receivedBodyBytes += chunk.byteLength;
               try {
                 controller.enqueue(chunk);
               } catch {
@@ -265,7 +282,11 @@ export class H2Session {
             });
             stream.on('end', () => {
               try {
-                controller.close();
+                if (goawayCause && expectedBodyBytes !== undefined && receivedBodyBytes < expectedBodyBytes) {
+                  controller.error(goawayCause);
+                } else {
+                  controller.close();
+                }
               } catch {
                 // Already closed/cancelled — ignore
               }
@@ -273,7 +294,7 @@ export class H2Session {
             });
             stream.on('error', (err) => {
               try {
-                controller.error(err);
+                controller.error(goawayCause ?? err);
               } catch {
                 // controller may already be closed
               }

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -26,6 +26,21 @@ const DEFAULT_INITIAL_WINDOW_SIZE = 16 * 1024 * 1024; // 16 MB
 
 const createAbortError = (): Error => Object.assign(new Error('Request aborted'), { name: 'AbortError' });
 
+/** Cause retained when a peer ends an HTTP/2 session with GOAWAY. */
+export class H2GoawayError extends Error {
+  readonly code = 'ERR_HTTP2_GOAWAY_SESSION';
+
+  constructor(
+    readonly errorCode: number,
+    readonly lastStreamID: number,
+    readonly opaqueData?: Uint8Array,
+  ) {
+    const debug = opaqueData ? Buffer.from(opaqueData).toString('utf8') : '';
+    super(`HTTP/2 GOAWAY (error code ${errorCode}, last stream ${lastStreamID})${debug ? `: ${debug}` : ''}`);
+    this.name = 'H2GoawayError';
+  }
+}
+
 export class H2Session {
   readonly origin: string;
 
@@ -35,6 +50,9 @@ export class H2Session {
   private _session: http2.ClientHttp2Session | null = null;
   private _connectPromise: Promise<void> | null = null;
   private readonly _opts: H2SessionOptions;
+  private readonly _goawayHandlers = new Set<
+    (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => void
+  >();
 
   /** Called by the pool when a stream slot frees up. */
   onAvailable: (() => void) | null = null;
@@ -69,7 +87,10 @@ export class H2Session {
 
       const timeout = setTimeout(() => {
         session.destroy(
-          new Error(`H2 connect timeout after ${this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT}ms`),
+          Object.assign(
+            new Error(`H2 connect timeout after ${this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT}ms`),
+            { code: 'UND_ERR_CONNECT_TIMEOUT' },
+          ),
         );
       }, this._opts.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT);
 
@@ -103,8 +124,11 @@ export class H2Session {
         }
       });
 
-      session.on('goaway', () => {
+      session.on('goaway', (errorCode, lastStreamID, opaqueData) => {
         this._state = SessionState.DRAINING;
+        for (const handler of [...this._goawayHandlers]) {
+          handler(errorCode, lastStreamID, opaqueData);
+        }
         if (this._activeStreams === 0) {
           this._close();
         }
@@ -175,6 +199,7 @@ export class H2Session {
         this._activeStreams--;
         if (this._activeStreams === 0) this._session?.unref();
         if (signal) signal.removeEventListener('abort', onAbort);
+        this._goawayHandlers.delete(onGoaway);
         if (this._state === SessionState.DRAINING && this._activeStreams === 0) {
           this._close();
         }
@@ -184,6 +209,21 @@ export class H2Session {
       };
 
       stream.once('close', cleanup);
+
+      const onGoaway = (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {
+        // A stream above lastStreamID was not processed by the peer. Preserve all
+        // GOAWAY metadata instead of replacing it with node:http2's generic error.
+        const idleTimeout = opaqueData?.includes(Buffer.from('idle_timeout')) ?? false;
+        if (!settled && (idleTimeout || (typeof stream.id === 'number' && stream.id > lastStreamID))) {
+          settled = true;
+          const cause = new H2GoawayError(errorCode, lastStreamID, opaqueData);
+          cleanup();
+          stream.on('error', () => {});
+          stream.destroy();
+          reject(cause);
+        }
+      };
+      this._goawayHandlers.add(onGoaway);
 
       stream.on('error', (err) => {
         if (!settled) {

--- a/src/lib/h2-transport/session.ts
+++ b/src/lib/h2-transport/session.ts
@@ -34,6 +34,7 @@ export class H2GoawayError extends Error {
     readonly errorCode: number,
     readonly lastStreamID: number,
     readonly opaqueData?: Uint8Array,
+    readonly unprocessed = false,
   ) {
     const debug = opaqueData ? Buffer.from(opaqueData).toString('utf8') : '';
     super(`HTTP/2 GOAWAY (error code ${errorCode}, last stream ${lastStreamID})${debug ? `: ${debug}` : ''}`);
@@ -175,6 +176,7 @@ export class H2Session {
 
       let settled = false;
       let cleaned = false;
+      let goawayCause: H2GoawayError | undefined;
 
       const onAbort = () => {
         if (!cleaned) {
@@ -209,19 +211,30 @@ export class H2Session {
         this.onAvailable?.();
       };
 
-      stream.once('close', cleanup);
+      stream.once('close', () => {
+        if (!settled) {
+          settled = true;
+          reject(
+            goawayCause ??
+              Object.assign(new Error('HTTP/2 stream closed before response headers.'), {
+                code: 'ERR_HTTP2_STREAM_ERROR',
+              }),
+          );
+        }
+        cleanup();
+      });
 
       const onGoaway = (errorCode: number, lastStreamID: number, opaqueData?: Buffer) => {
         // A stream above lastStreamID was not processed by the peer. Preserve all
         // GOAWAY metadata instead of replacing it with node:http2's generic error.
-        const idleTimeout = opaqueData?.includes(Buffer.from('idle_timeout')) ?? false;
-        if (!settled && (idleTimeout || (typeof stream.id === 'number' && stream.id > lastStreamID))) {
+        const unprocessed = typeof stream.id === 'number' && stream.id > lastStreamID;
+        goawayCause = new H2GoawayError(errorCode, lastStreamID, opaqueData, unprocessed);
+        if (!settled && unprocessed) {
           settled = true;
-          const cause = new H2GoawayError(errorCode, lastStreamID, opaqueData);
           cleanup();
           stream.on('error', () => {});
           stream.destroy();
-          reject(cause);
+          reject(goawayCause);
         }
       };
       this._goawayHandlers.add(onGoaway);
@@ -230,7 +243,7 @@ export class H2Session {
         if (!settled) {
           settled = true;
           cleanup();
-          reject(err);
+          reject(goawayCause ?? err);
         }
       });
 

--- a/src/lib/tunnel-readiness.ts
+++ b/src/lib/tunnel-readiness.ts
@@ -1,0 +1,73 @@
+import { APIConnectionError, APIError } from '../error';
+
+export interface TunnelReadinessOptions {
+  /** Overall bounded deadline in milliseconds. Defaults to 30 seconds. */
+  timeoutMs?: number;
+  /** Delay used when the server does not provide Retry-After. Defaults to 250ms. */
+  retryIntervalMs?: number;
+  signal?: AbortSignal;
+}
+
+const READINESS_CODES = new Set([
+  'tunnel_service_not_ready',
+  'tunnel_backend_connect_timeout',
+  'tunnel_unavailable',
+]);
+
+function canRetryReadiness(error: unknown): error is APIError {
+  if (!(error instanceof APIError) || error.retryable === false) return false;
+  if (error instanceof APIConnectionError) return error.phase === 'connect';
+  return READINESS_CODES.has(error.code ?? '') && error.phase !== 'response_read';
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('Tunnel readiness wait aborted'));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('Tunnel readiness wait aborted'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Poll an idempotent tunnel GET until it is ready, retaining the last normalized failure. */
+export async function awaitTunnelServiceReady<T>(
+  request: (remainingMs: number) => Promise<T>,
+  options: TunnelReadinessOptions = {},
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const retryIntervalMs = options.retryIntervalMs ?? 250;
+  if (timeoutMs <= 0) throw new RangeError('timeoutMs must be positive');
+  if (retryIntervalMs < 0) throw new RangeError('retryIntervalMs must not be negative');
+
+  const deadline = Date.now() + timeoutMs;
+  let attempts = 0;
+  while (true) {
+    attempts++;
+    try {
+      return await request(Math.max(1, deadline - Date.now()));
+    } catch (error) {
+      if (!canRetryReadiness(error)) {
+        if (error instanceof APIError) {
+          Object.defineProperty(error, 'attempts', { value: attempts, configurable: true });
+        }
+        throw error;
+      }
+      const remaining = deadline - Date.now();
+      const requestedDelay = error.retryAfter === undefined ? retryIntervalMs : error.retryAfter * 1000;
+      if (remaining <= 0 || requestedDelay >= remaining) {
+        Object.defineProperty(error, 'attempts', { value: attempts, configurable: true });
+        throw error;
+      }
+      await delay(requestedDelay, options.signal);
+    }
+  }
+}

--- a/src/lib/tunnel-readiness.ts
+++ b/src/lib/tunnel-readiness.ts
@@ -1,23 +1,18 @@
-import { APIConnectionError, APIError } from '../error';
+import { APIError } from '../error';
 
 export interface TunnelReadinessOptions {
   /** Overall bounded deadline in milliseconds. Defaults to 30 seconds. */
   timeoutMs?: number;
   /** Delay used when the server does not provide Retry-After. Defaults to 250ms. */
   retryIntervalMs?: number;
+  /** Health endpoint requested through the established tunnel. Defaults to `/`. */
+  path?: string;
   signal?: AbortSignal;
 }
 
-const READINESS_CODES = new Set([
-  'tunnel_service_not_ready',
-  'tunnel_backend_connect_timeout',
-  'tunnel_unavailable',
-]);
-
 function canRetryReadiness(error: unknown): error is APIError {
   if (!(error instanceof APIError) || error.retryable === false) return false;
-  if (error instanceof APIConnectionError) return error.phase === 'connect';
-  return READINESS_CODES.has(error.code ?? '') && error.phase !== 'response_read';
+  return error.code === 'tunnel_service_not_ready';
 }
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {
@@ -63,7 +58,7 @@ export async function awaitTunnelServiceReady<T>(
       }
       const remaining = deadline - Date.now();
       const requestedDelay = error.retryAfter === undefined ? retryIntervalMs : error.retryAfter * 1000;
-      if (remaining <= 0 || requestedDelay >= remaining) {
+      if (remaining <= 0 || requestedDelay >= remaining || attempts >= 1000) {
         Object.defineProperty(error, 'attempts', { value: attempts, configurable: true });
         throw error;
       }

--- a/src/sdk/devbox.ts
+++ b/src/sdk/devbox.ts
@@ -178,9 +178,9 @@ export class DevboxNetOps {
             maxRetries: 0,
             timeout: remainingMs,
             signal: options.signal,
-            // Never forward a tunnel credential (or the client's API bearer)
-            // to a Location chosen by the tunneled service.
-            redirect: 'error',
+            // Surface redirects as terminal API errors without forwarding a
+            // tunnel credential to a Location chosen by the tunneled service.
+            redirect: 'manual',
             headers: {
               // Remove the API bearer and use the tunnel-specific credential header.
               authorization: null,

--- a/src/sdk/devbox.ts
+++ b/src/sdk/devbox.ts
@@ -182,7 +182,10 @@ export class DevboxNetOps {
             // to a Location chosen by the tunneled service.
             redirect: 'error',
             headers: {
-              authorization: info.tunnel?.auth_token ? `Bearer ${info.tunnel.auth_token}` : null,
+              // Remove the API bearer and use the tunnel-specific credential header.
+              authorization: null,
+              'x-runloop-tunnel-authorization':
+                info.tunnel?.auth_token ? `Bearer ${info.tunnel.auth_token}` : null,
             },
           })
           .asResponse(),

--- a/src/sdk/devbox.ts
+++ b/src/sdk/devbox.ts
@@ -178,6 +178,9 @@ export class DevboxNetOps {
             maxRetries: 0,
             timeout: remainingMs,
             signal: options.signal,
+            // Never forward a tunnel credential (or the client's API bearer)
+            // to a Location chosen by the tunneled service.
+            redirect: 'error',
             headers: {
               authorization: info.tunnel?.auth_token ? `Bearer ${info.tunnel.auth_token}` : null,
             },

--- a/src/sdk/devbox.ts
+++ b/src/sdk/devbox.ts
@@ -147,17 +147,30 @@ export class DevboxNetOps {
   }
 
   /**
-   * Wait until an enabled tunnel is accepting requests. Only explicit tunnel
-   * readiness/connect failures are retried, within a bounded deadline.
+   * Wait until an enabled tunnel is accepting requests. Only
+   * `tunnel_service_not_ready` is retried, within a bounded deadline.
    */
   async awaitTunnelReady(port: number, options: TunnelReadinessOptions = {}): Promise<Core.Response> {
-    const info = await this.client.devboxes.retrieve(this.devboxId, { maxRetries: 0 });
+    const timeoutMs = options.timeoutMs ?? 30_000;
+    if (timeoutMs <= 0) throw new RangeError('timeoutMs must be positive');
+    const path = options.path ?? '/';
+    if (!path.startsWith('/') || path.startsWith('//')) {
+      throw new RangeError('path must be an absolute tunnel path beginning with a single `/`');
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    const info = await this.client.devboxes.retrieve(this.devboxId, {
+      maxRetries: 0,
+      timeout: timeoutMs,
+      signal: options.signal,
+    });
     if (!info.tunnel) {
       throw new RunloopError('No tunnel has been enabled for this devbox. Call net.enableTunnel() first.');
     }
     const apiHost = new URL(this.client.baseURL).hostname;
     const baseDomain = apiHost.startsWith('api.') ? apiHost.slice(4) : apiHost;
-    const url = `https://${port}-${info.tunnel.tunnel_key}.tunnel.${baseDomain}`;
+    const url = `https://${port}-${info.tunnel.tunnel_key}.tunnel.${baseDomain}${path}`;
+    const remainingMs = Math.max(1, deadline - Date.now());
     return awaitTunnelServiceReady(
       (remainingMs) =>
         this.client
@@ -170,7 +183,7 @@ export class DevboxNetOps {
             },
           })
           .asResponse(),
-      options,
+      { ...options, timeoutMs: remainingMs },
     );
   }
 }

--- a/src/sdk/devbox.ts
+++ b/src/sdk/devbox.ts
@@ -24,6 +24,7 @@ import { Execution } from './execution';
 import { ExecutionResult } from './execution-result';
 import { EvictionCallback, getEvictionMonitor } from './eviction';
 import { uuidv7 } from 'uuidv7';
+import { awaitTunnelServiceReady, type TunnelReadinessOptions } from '../lib/tunnel-readiness';
 
 // Re-export Execution and ExecutionResult for Devbox namespace
 export { Execution } from './execution';
@@ -143,6 +144,34 @@ export class DevboxNetOps {
    */
   async removeTunnel(options?: Core.RequestOptions) {
     return this.client.devboxes.removeTunnel(this.devboxId, options);
+  }
+
+  /**
+   * Wait until an enabled tunnel is accepting requests. Only explicit tunnel
+   * readiness/connect failures are retried, within a bounded deadline.
+   */
+  async awaitTunnelReady(port: number, options: TunnelReadinessOptions = {}): Promise<Core.Response> {
+    const info = await this.client.devboxes.retrieve(this.devboxId, { maxRetries: 0 });
+    if (!info.tunnel) {
+      throw new RunloopError('No tunnel has been enabled for this devbox. Call net.enableTunnel() first.');
+    }
+    const apiHost = new URL(this.client.baseURL).hostname;
+    const baseDomain = apiHost.startsWith('api.') ? apiHost.slice(4) : apiHost;
+    const url = `https://${port}-${info.tunnel.tunnel_key}.tunnel.${baseDomain}`;
+    return awaitTunnelServiceReady(
+      (remainingMs) =>
+        this.client
+          .get(url, {
+            maxRetries: 0,
+            timeout: remainingMs,
+            signal: options.signal,
+            headers: {
+              authorization: info.tunnel?.auth_token ? `Bearer ${info.tunnel.auth_token}` : null,
+            },
+          })
+          .asResponse(),
+      options,
+    );
   }
 }
 
@@ -842,6 +871,11 @@ export class Devbox {
     const apiHost = new URL(this.client.baseURL).hostname;
     const baseDomain = apiHost.startsWith('api.') ? apiHost.slice(4) : apiHost;
     return `https://${port}-${tunnel.tunnel_key}.tunnel.${baseDomain}`;
+  }
+
+  /** Wait until the tunnel service for a port is ready. */
+  async awaitTunnelReady(port: number, options?: TunnelReadinessOptions): Promise<Core.Response> {
+    return this.net.awaitTunnelReady(port, options);
   }
 
   /**

--- a/src/sdk/eviction.ts
+++ b/src/sdk/eviction.ts
@@ -116,7 +116,7 @@ export class EvictionMonitor {
           if (this.entries.size === 0) return;
           // Otherwise a routine disconnect — fall through to backoff + reconnect.
         }
-        if (this.entries.size === 0) return;
+        if (generation !== this.generation || this.entries.size === 0) return;
         await this.waitForRetry(backoff);
         backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
       }

--- a/src/sdk/eviction.ts
+++ b/src/sdk/eviction.ts
@@ -31,6 +31,8 @@ export class EvictionMonitor {
   private entries = new Map<string, { devbox: Devbox; callback: EvictionCallback }>();
   private stream: Stream<DevboxEvictionEventView> | null = null;
   private running = false;
+  private generation = 0;
+  private cancelBackoff: (() => void) | null = null;
 
   constructor(private client: Runloop) {}
 
@@ -39,7 +41,8 @@ export class EvictionMonitor {
     this.entries.set(devbox.id, { devbox, callback });
     if (!this.running) {
       this.running = true;
-      void this.run();
+      const generation = ++this.generation;
+      void this.run(generation);
     }
   }
 
@@ -56,10 +59,30 @@ export class EvictionMonitor {
     this.entries.clear();
     this.stream?.controller.abort();
     this.stream = null;
+    // A disconnect may have put the monitor in its reconnect delay. Wake that
+    // delay immediately so it neither keeps a test worker/process alive nor
+    // reconnects after the final registration has been removed.
+    this.cancelBackoff?.();
     this.running = false;
+    this.generation++;
   }
 
-  private async run(): Promise<void> {
+  private waitForRetry(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
+        if (!timer) return;
+        clearTimeout(timer);
+        timer = undefined;
+        if (this.cancelBackoff === finish) this.cancelBackoff = null;
+        resolve();
+      };
+      timer = setTimeout(finish, ms);
+      this.cancelBackoff = finish;
+    });
+  }
+
+  private async run(generation: number): Promise<void> {
     // The server force-closes the stream on purpose (leader change / slow consumer) and a
     // long-lived HTTP/2 stream can drop; the client is expected to reconnect and re-read the
     // snapshot, which re-delivers anything missed. So reconnect (with backoff) until no devbox is
@@ -68,7 +91,7 @@ export class EvictionMonitor {
     const MAX_BACKOFF_MS = 30_000;
     let backoff = INITIAL_BACKOFF_MS;
     try {
-      while (this.entries.size > 0) {
+      while (generation === this.generation && this.entries.size > 0) {
         try {
           // Force the SSE Accept header: the endpoint only streams for text/event-stream; the
           // generated client's default (application/json) gets an empty text/plain response, so the
@@ -76,6 +99,10 @@ export class EvictionMonitor {
           const stream = await this.client.devboxes.watchEvictions({
             headers: { Accept: 'text/event-stream' },
           });
+          if (generation !== this.generation) {
+            stream.controller.abort();
+            return;
+          }
           this.stream = stream;
           for await (const event of stream) {
             this.dispatch(event);
@@ -90,12 +117,14 @@ export class EvictionMonitor {
           // Otherwise a routine disconnect — fall through to backoff + reconnect.
         }
         if (this.entries.size === 0) return;
-        await new Promise((resolve) => setTimeout(resolve, backoff));
+        await this.waitForRetry(backoff);
         backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
       }
     } finally {
-      this.stream = null;
-      this.running = false;
+      if (generation === this.generation) {
+        this.stream = null;
+        this.running = false;
+      }
     }
   }
 

--- a/tests/error-details.test.ts
+++ b/tests/error-details.test.ts
@@ -288,6 +288,41 @@ describe('stable Runloop error details', () => {
     await expect(client.get('/v1/custom-parser')).rejects.toBe(parserError);
   });
 
+  test('does not mask parser errors whose cause is a TypeError', async () => {
+    const parserError = Object.assign(new Error('custom parser failed'), {
+      cause: new TypeError('invalid parser input'),
+    });
+    const response = new Response('{}', { headers: { 'content-type': 'application/json' } });
+    response.json = jest.fn().mockRejectedValue(parserError);
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: jest.fn().mockResolvedValue(response) as any,
+    });
+
+    await expect(client.get('/v1/custom-parser')).rejects.toBe(parserError);
+  });
+
+  test('does not mask TypeErrors caused by locked response bodies', async () => {
+    const parserError = new TypeError('response body is locked');
+    class LockedResponse extends Response {
+      override json(): Promise<never> {
+        return Promise.reject(parserError);
+      }
+    }
+    const response = new LockedResponse('{}', { headers: { 'content-type': 'application/json' } });
+    Object.defineProperty(response.body, 'locked', { value: true });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: jest.fn().mockResolvedValue(response) as any,
+    });
+
+    await expect(client.get('/v1/locked-body')).rejects.toBe(parserError);
+  });
+
   test('normalizes bare TypeErrors from native response body readers', async () => {
     const transportError = new TypeError('network connection lost while reading the response body');
     class NetworkFailureResponse extends Response {

--- a/tests/error-details.test.ts
+++ b/tests/error-details.test.ts
@@ -1,0 +1,209 @@
+import {
+  Runloop,
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  InternalServerError,
+} from '@runloop/api-client';
+import { Response, type RequestInfo, type RequestInit } from 'node-fetch';
+import { awaitTunnelServiceReady } from '../src/lib/tunnel-readiness';
+
+describe('stable Runloop error details', () => {
+  test.each([
+    ['UND_ERR_CONNECT_TIMEOUT', 'connection_timeout', 'connect', true],
+    ['UND_ERR_HEADERS_TIMEOUT', 'response_headers_timeout', 'response_headers', false],
+    ['UND_ERR_BODY_TIMEOUT', 'response_read_timeout', 'response_read', false],
+    ['ECONNRESET', 'connection_reset', 'transport', false],
+    ['ERR_HTTP2_STREAM_ERROR', 'http2_protocol_error', 'transport', false],
+  ])('normalizes %s', async (nativeCode, code, phase, retryable) => {
+    const cause = Object.assign(new Error(nativeCode), { code: nativeCode });
+    const fetchError = Object.assign(new TypeError('fetch failed'), { cause });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: (() => Promise.reject(fetchError)) as any,
+    });
+
+    const error: any = await client.get('/v1/test').catch((value) => value);
+    expect(error).toBeInstanceOf(
+      nativeCode === 'UND_ERR_CONNECT_TIMEOUT' ? APIConnectionTimeoutError : APIConnectionError,
+    );
+    expect(error).toMatchObject({ code, phase, retryable, attempts: 1, cause: fetchError });
+  });
+
+  test('distinguishes an SDK-owned AbortError deadline', async () => {
+    const lowLevelAbort = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      timeout: 1,
+      fetch: ((_url: RequestInfo, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(lowLevelAbort), { once: true });
+        })) as any,
+    });
+
+    const error: any = await client.get('/v1/test').catch((value) => value);
+    expect(error).toBeInstanceOf(APIConnectionTimeoutError);
+    expect(error).toMatchObject({
+      code: 'request_timeout',
+      phase: 'request',
+      retryable: true,
+      attempts: 1,
+      cause: lowLevelAbort,
+    });
+  });
+
+  test('normalizes an injected HTTP/2 idle GOAWAY and preserves its cause', async () => {
+    const cause = Object.assign(new Error('HTTP/2 connection terminated: idle_timeout'), {
+      code: 'ERR_HTTP2_GOAWAY_SESSION',
+    });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: (() => Promise.reject(cause)) as any,
+    });
+
+    const error: any = await client.get('/v1/test').catch((value) => value);
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect(error).toMatchObject({
+      code: 'http2_idle_timeout',
+      phase: 'response_read',
+      retryable: false,
+      attempts: 1,
+      cause,
+    });
+  });
+
+  test('parses a tunnel readiness response with header precedence', async () => {
+    const fetch = jest.fn((_url: RequestInfo, _init?: RequestInit) =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: 'legacy_code',
+            message: 'Tunnel service is starting',
+            retryable: true,
+            phase: 'readiness',
+            request_id: 'body-request',
+            details: { state: 'starting' },
+          }),
+          {
+            status: 503,
+            headers: {
+              'content-type': 'application/json',
+              'x-runloop-error-code': 'tunnel_service_not_ready',
+              'x-runloop-request-id': 'header-request',
+              'retry-after': '2',
+              'x-should-retry': 'true',
+            },
+          },
+        ),
+      ),
+    );
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: fetch as any,
+    });
+
+    const error: any = await client.get('/v1/tunnels/readiness').catch((value) => value);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(error).toBeInstanceOf(InternalServerError);
+    expect(error.message).toBe('503 Tunnel service is starting');
+    expect(error).toMatchObject({
+      code: 'tunnel_service_not_ready',
+      phase: 'readiness',
+      retryable: true,
+      requestID: 'header-request',
+      retryAfter: 2,
+      attempts: 1,
+    });
+  });
+
+  test('honors retry headers and reports attempts on the final normalized failure', async () => {
+    const fetch = jest.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'tunnel_service_not_ready', retryable: true }), {
+          status: 503,
+          headers: {
+            'content-type': 'application/json',
+            'x-should-retry': 'true',
+            'retry-after': '0',
+          },
+        }),
+      ),
+    );
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 1,
+      fetch: fetch as any,
+    });
+
+    const error: any = await client.get('/v1/tunnels/readiness').catch((value) => value);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(error).toMatchObject({ code: 'tunnel_service_not_ready', attempts: 2 });
+  });
+
+  test('does not retry execute calls with ambiguous server receipt', async () => {
+    const fetch = jest.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'tunnel_unavailable', retryable: true }), {
+          status: 503,
+          headers: { 'content-type': 'application/json', 'x-should-retry': 'true' },
+        }),
+      ),
+    );
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 2,
+      fetch: fetch as any,
+    });
+
+    const error: any = await client
+      .post('/v1/devboxes/dbx/executions/execute', { body: { command: 'true' } })
+      .catch((value) => value);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(error.attempts).toBe(1);
+  });
+
+  test('does not blindly retry a response-idle failure', async () => {
+    const fetch = jest.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'tunnel_backend_idle_timeout', retryable: false }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 2,
+      fetch: fetch as any,
+    });
+
+    const error: any = await client.get('/v1/tunnel').catch((value) => value);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(error).toMatchObject({ code: 'tunnel_backend_idle_timeout', attempts: 1 });
+  });
+
+  test('tunnel readiness helper retries only the explicit readiness failure', async () => {
+    const notReady = InternalServerError.generate(
+      503,
+      { error: 'tunnel_service_not_ready', retryable: true, phase: 'readiness' },
+      undefined,
+      { 'retry-after': '0' },
+    );
+    const request = jest.fn().mockRejectedValueOnce(notReady).mockResolvedValueOnce('ready');
+
+    await expect(awaitTunnelServiceReady(request, { timeoutMs: 1000, retryIntervalMs: 0 })).resolves.toBe(
+      'ready',
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/error-details.test.ts
+++ b/tests/error-details.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@runloop/api-client';
 import { Response, type RequestInfo, type RequestInit } from 'node-fetch';
 import { awaitTunnelServiceReady } from '../src/lib/tunnel-readiness';
+import { PassThrough } from 'node:stream';
 
 describe('stable Runloop error details', () => {
   test.each([
@@ -171,10 +172,31 @@ describe('stable Runloop error details', () => {
     expect(error.attempts).toBe(1);
   });
 
+  test('tunnel_unavailable remains terminal even when retry headers disagree', async () => {
+    const fetch = jest.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ error: 'tunnel_unavailable', retryable: true }), {
+          status: 503,
+          headers: { 'content-type': 'application/json', 'x-should-retry': 'true' },
+        }),
+      ),
+    );
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 2,
+      fetch: fetch as any,
+    });
+
+    const error: any = await client.get('/v1/tunnel').catch((value) => value);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(error).toMatchObject({ code: 'tunnel_unavailable', attempts: 1 });
+  });
+
   test('does not blindly retry a response-idle failure', async () => {
     const fetch = jest.fn(() =>
       Promise.resolve(
-        new Response(JSON.stringify({ error: 'tunnel_backend_idle_timeout', retryable: false }), {
+        new Response(JSON.stringify({ code: 'tunnel_backend_idle_timeout', retryable: false }), {
           status: 503,
           headers: { 'content-type': 'application/json' },
         }),
@@ -192,6 +214,28 @@ describe('stable Runloop error details', () => {
     expect(error).toMatchObject({ code: 'tunnel_backend_idle_timeout', attempts: 1 });
   });
 
+  test('bounds error response body reads with the request deadline', async () => {
+    const body = new PassThrough();
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      timeout: 20,
+      fetch: (() =>
+        Promise.resolve(
+          new Response(body, { status: 503, headers: { 'content-type': 'application/json' } }),
+        )) as any,
+    });
+
+    try {
+      const error: any = await client.get('/v1/stalled-error').catch((value) => value);
+      expect(error).toBeInstanceOf(APIConnectionTimeoutError);
+      expect(error).toMatchObject({ code: 'request_timeout', attempts: 1 });
+    } finally {
+      body.destroy();
+    }
+  });
+
   test('tunnel readiness helper retries only the explicit readiness failure', async () => {
     const notReady = InternalServerError.generate(
       503,
@@ -205,5 +249,21 @@ describe('stable Runloop error details', () => {
       'ready',
     );
     expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  test('tunnel_unavailable is terminal for tunnel readiness', async () => {
+    const unavailable = InternalServerError.generate(
+      503,
+      { error: 'tunnel_unavailable', retryable: true, phase: 'tunnel_readiness' },
+      undefined,
+      {},
+    );
+    const request = jest.fn().mockRejectedValue(unavailable);
+
+    await expect(awaitTunnelServiceReady(request, { timeoutMs: 1_000, retryIntervalMs: 0 })).rejects.toBe(
+      unavailable,
+    );
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(unavailable.attempts).toBe(1);
   });
 });

--- a/tests/error-details.test.ts
+++ b/tests/error-details.test.ts
@@ -288,6 +288,28 @@ describe('stable Runloop error details', () => {
     await expect(client.get('/v1/custom-parser')).rejects.toBe(parserError);
   });
 
+  test('normalizes bare TypeErrors from native response body readers', async () => {
+    const transportError = new TypeError('network connection lost while reading the response body');
+    class NetworkFailureResponse extends Response {
+      override json(): Promise<never> {
+        return Promise.reject(transportError);
+      }
+    }
+    const response = new NetworkFailureResponse('{}', {
+      headers: { 'content-type': 'application/json' },
+    });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: jest.fn().mockResolvedValue(response) as any,
+    });
+
+    const error: any = await client.get('/v1/body-failure').catch((value) => value);
+    expect(error).toBeInstanceOf(APIConnectionError);
+    expect(error).toMatchObject({ code: 'connection_error', phase: 'transport', cause: transportError });
+  });
+
   test('tunnel readiness helper retries only the explicit readiness failure', async () => {
     const notReady = InternalServerError.generate(
       503,

--- a/tests/error-details.test.ts
+++ b/tests/error-details.test.ts
@@ -236,6 +236,42 @@ describe('stable Runloop error details', () => {
     }
   });
 
+  test('retries a safe request when an error response body reaches the SDK deadline', async () => {
+    const stalled = new PassThrough();
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce(new Response(stalled, { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }));
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 1,
+      timeout: 20,
+      fetch: fetch as any,
+    });
+
+    try {
+      await expect(client.get('/v1/retry-safe')).resolves.toEqual({ ok: true });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      stalled.destroy();
+    }
+  });
+
+  test('does not mask coded response parser failures as transport errors', async () => {
+    const parserError = Object.assign(new Error('custom parser failed'), { code: 'APP_PARSE_ERROR' });
+    const response = new Response('{}', { headers: { 'content-type': 'application/json' } });
+    response.json = jest.fn().mockRejectedValue(parserError);
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: jest.fn().mockResolvedValue(response) as any,
+    });
+
+    await expect(client.get('/v1/custom-parser')).rejects.toBe(parserError);
+  });
+
   test('tunnel readiness helper retries only the explicit readiness failure', async () => {
     const notReady = InternalServerError.generate(
       503,

--- a/tests/error-details.test.ts
+++ b/tests/error-details.test.ts
@@ -241,7 +241,9 @@ describe('stable Runloop error details', () => {
     const fetch = jest
       .fn()
       .mockResolvedValueOnce(new Response(stalled, { status: 503 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }));
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } }),
+      );
     const client = new Runloop({
       bearerToken: 'test',
       baseURL: 'https://example.invalid',
@@ -260,6 +262,20 @@ describe('stable Runloop error details', () => {
 
   test('does not mask coded response parser failures as transport errors', async () => {
     const parserError = Object.assign(new Error('custom parser failed'), { code: 'APP_PARSE_ERROR' });
+    const response = new Response('{}', { headers: { 'content-type': 'application/json' } });
+    response.json = jest.fn().mockRejectedValue(parserError);
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: jest.fn().mockResolvedValue(response) as any,
+    });
+
+    await expect(client.get('/v1/custom-parser')).rejects.toBe(parserError);
+  });
+
+  test('does not mask uncoded TypeErrors from response parsers as transport errors', async () => {
+    const parserError = new TypeError('response body has already been consumed');
     const response = new Response('{}', { headers: { 'content-type': 'application/json' } });
     response.json = jest.fn().mockRejectedValue(parserError);
     const client = new Runloop({

--- a/tests/lib/h2-transport/helpers/faultServer.ts
+++ b/tests/lib/h2-transport/helpers/faultServer.ts
@@ -6,6 +6,8 @@ export interface FaultPlan {
   goawayOnStream?: number;
   /** Send GOAWAY with idle_timeout debug data before response headers. */
   idleTimeoutGoawayBeforeHeadersOnStream?: number;
+  /** Send GOAWAY with idle_timeout debug data after partial response data. */
+  idleTimeoutGoawayDuringBodyOnStream?: number;
   /** RST_STREAM with the given code for the first N streams. */
   rstFirstNStreams?: { count: number; code: number };
   /** Delay headers by this many ms. */
@@ -63,6 +65,20 @@ export function startFaultServer(): Promise<FaultServer> {
       if (plan.idleTimeoutGoawayBeforeHeadersOnStream === n) {
         stream.session?.goaway(http2.constants.NGHTTP2_NO_ERROR, 0, Buffer.from('idle_timeout'));
         stream.close(http2.constants.NGHTTP2_CANCEL);
+        return;
+      }
+
+      if (plan.idleTimeoutGoawayDuringBodyOnStream === n) {
+        stream.respond({ ':status': 200, 'content-type': 'application/json', 'content-length': '100' });
+        stream.write('{"partial":');
+        setImmediate(() => {
+          stream.session?.goaway(
+            http2.constants.NGHTTP2_NO_ERROR,
+            stream.id ?? 0,
+            Buffer.from('idle_timeout'),
+          );
+          stream.close(http2.constants.NGHTTP2_INTERNAL_ERROR);
+        });
         return;
       }
 

--- a/tests/lib/h2-transport/helpers/faultServer.ts
+++ b/tests/lib/h2-transport/helpers/faultServer.ts
@@ -4,6 +4,8 @@ import { ensureCerts } from './certs';
 export interface FaultPlan {
   /** Send GOAWAY to the session as soon as the Nth stream opens. */
   goawayOnStream?: number;
+  /** Send GOAWAY with idle_timeout debug data before response headers. */
+  idleTimeoutGoawayBeforeHeadersOnStream?: number;
   /** RST_STREAM with the given code for the first N streams. */
   rstFirstNStreams?: { count: number; code: number };
   /** Delay headers by this many ms. */
@@ -55,6 +57,12 @@ export function startFaultServer(): Promise<FaultServer> {
         stream.respond({ ':status': 200, 'content-type': 'text/plain' });
         stream.end('ok-then-goaway');
         stream.session?.goaway();
+        return;
+      }
+
+      if (plan.idleTimeoutGoawayBeforeHeadersOnStream === n) {
+        stream.session?.goaway(http2.constants.NGHTTP2_NO_ERROR, 0, Buffer.from('idle_timeout'));
+        stream.close(http2.constants.NGHTTP2_CANCEL);
         return;
       }
 

--- a/tests/lib/h2-transport/idle-timeout.test.ts
+++ b/tests/lib/h2-transport/idle-timeout.test.ts
@@ -81,6 +81,21 @@ describe('HTTP/2 idle timeout GOAWAY', () => {
     }
   });
 
+  test('retains GOAWAY metadata for binary response consumers', async () => {
+    server.setPlan({ idleTimeoutGoawayDuringBodyOnStream: 1 });
+    const h2Fetch = createH2Fetch({ minConnections: 1, maxConnections: 1, tlsOptions: testTls });
+
+    try {
+      const response = await h2Fetch(`${server.origin}/idle-binary`, { method: 'GET' });
+      const error: any = await response.arrayBuffer().catch((value) => value);
+      expect(error).toBeInstanceOf(H2GoawayError);
+      expect(error).toMatchObject({ code: 'ERR_HTTP2_GOAWAY_SESSION', unprocessed: false });
+      expect(Buffer.from(error.opaqueData).toString()).toBe('idle_timeout');
+    } finally {
+      await h2Fetch.close();
+    }
+  });
+
   test('closes a draining session exactly once', async () => {
     server.setPlan({ idleTimeoutGoawayBeforeHeadersOnStream: 1 });
     const session = new H2Session(server.origin, { tlsOptions: testTls });

--- a/tests/lib/h2-transport/idle-timeout.test.ts
+++ b/tests/lib/h2-transport/idle-timeout.test.ts
@@ -41,6 +41,7 @@ describe('HTTP/2 idle timeout GOAWAY', () => {
         code: 'ERR_HTTP2_GOAWAY_SESSION',
         errorCode: 0,
         lastStreamID: 1,
+        unprocessed: false,
       });
       expect(Buffer.from(error.cause.opaqueData).toString()).toBe('idle_timeout');
       expect(server.streamCount()).toBe(1);

--- a/tests/lib/h2-transport/idle-timeout.test.ts
+++ b/tests/lib/h2-transport/idle-timeout.test.ts
@@ -50,6 +50,37 @@ describe('HTTP/2 idle timeout GOAWAY', () => {
     }
   });
 
+  test('retains GOAWAY metadata when the response body is interrupted', async () => {
+    server.setPlan({ idleTimeoutGoawayDuringBodyOnStream: 1 });
+    const h2Fetch = createH2Fetch({ minConnections: 1, maxConnections: 1, tlsOptions: testTls });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: server.origin,
+      maxRetries: 0,
+      fetch: h2Fetch,
+    });
+
+    try {
+      const error: any = await client.get('/idle-body').catch((value) => value);
+      expect(error).toBeInstanceOf(APIConnectionError);
+      expect(error).toMatchObject({
+        code: 'http2_idle_timeout',
+        phase: 'response_read',
+        retryable: false,
+        attempts: 1,
+      });
+      expect(error.cause).toBeInstanceOf(H2GoawayError);
+      expect(error.cause).toMatchObject({
+        code: 'ERR_HTTP2_GOAWAY_SESSION',
+        unprocessed: false,
+      });
+      expect(Buffer.from(error.cause.opaqueData).toString()).toBe('idle_timeout');
+      expect(server.streamCount()).toBe(1);
+    } finally {
+      await h2Fetch.close();
+    }
+  });
+
   test('closes a draining session exactly once', async () => {
     server.setPlan({ idleTimeoutGoawayBeforeHeadersOnStream: 1 });
     const session = new H2Session(server.origin, { tlsOptions: testTls });

--- a/tests/lib/h2-transport/idle-timeout.test.ts
+++ b/tests/lib/h2-transport/idle-timeout.test.ts
@@ -1,6 +1,7 @@
 import { Runloop, APIConnectionError } from '@runloop/api-client';
 import { createH2Fetch } from '../../../src/lib/h2-transport';
 import { H2GoawayError } from '../../../src/lib/h2-transport/session';
+import { H2Session } from '../../../src/lib/h2-transport/session';
 import { cleanupCerts, testTls } from './helpers/certs';
 import { startFaultServer, type FaultServer } from './helpers/faultServer';
 
@@ -46,5 +47,18 @@ describe('HTTP/2 idle timeout GOAWAY', () => {
     } finally {
       await h2Fetch.close();
     }
+  });
+
+  test('closes a draining session exactly once', async () => {
+    server.setPlan({ idleTimeoutGoawayBeforeHeadersOnStream: 1 });
+    const session = new H2Session(server.origin, { tlsOptions: testTls });
+    const onClose = jest.fn();
+    session.onClose = onClose;
+    await session.connect();
+
+    await expect(session.request('/idle', 'GET', {}, null)).rejects.toBeInstanceOf(H2GoawayError);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    await session.close();
   });
 });

--- a/tests/lib/h2-transport/idle-timeout.test.ts
+++ b/tests/lib/h2-transport/idle-timeout.test.ts
@@ -1,0 +1,50 @@
+import { Runloop, APIConnectionError } from '@runloop/api-client';
+import { createH2Fetch } from '../../../src/lib/h2-transport';
+import { H2GoawayError } from '../../../src/lib/h2-transport/session';
+import { cleanupCerts, testTls } from './helpers/certs';
+import { startFaultServer, type FaultServer } from './helpers/faultServer';
+
+describe('HTTP/2 idle timeout GOAWAY', () => {
+  let server: FaultServer;
+
+  beforeAll(async () => {
+    server = await startFaultServer();
+  });
+
+  afterAll(async () => {
+    await server.close();
+    cleanupCerts();
+  });
+
+  test('retains GOAWAY metadata and exposes a normalized final error', async () => {
+    server.setPlan({ idleTimeoutGoawayBeforeHeadersOnStream: 1 });
+    const h2Fetch = createH2Fetch({ minConnections: 1, maxConnections: 1, tlsOptions: testTls });
+    const client = new Runloop({
+      bearerToken: 'test',
+      baseURL: server.origin,
+      maxRetries: 0,
+      fetch: h2Fetch,
+    });
+
+    try {
+      const error: any = await client.get('/idle').catch((value) => value);
+      expect(error).toBeInstanceOf(APIConnectionError);
+      expect(error).toMatchObject({
+        code: 'http2_idle_timeout',
+        phase: 'response_read',
+        retryable: false,
+        attempts: 1,
+      });
+      expect(error.cause).toBeInstanceOf(H2GoawayError);
+      expect(error.cause).toMatchObject({
+        code: 'ERR_HTTP2_GOAWAY_SESSION',
+        errorCode: 0,
+        lastStreamID: 1,
+      });
+      expect(Buffer.from(error.cause.opaqueData).toString()).toBe('idle_timeout');
+      expect(server.streamCount()).toBe(1);
+    } finally {
+      await h2Fetch.close();
+    }
+  });
+});

--- a/tests/lib/h2-transport/index.test.ts
+++ b/tests/lib/h2-transport/index.test.ts
@@ -151,16 +151,16 @@ describe('createH2Fetch', () => {
     await fetch.close();
   });
 
-  test('rejects redirect responses when redirect mode is error', async () => {
+  test('returns redirect responses when redirect mode is manual', async () => {
     const redirectServer = await startTestServer((stream) => {
       stream.respond({ ':status': 302, location: 'https://attacker.invalid/collect' });
       stream.end();
     });
     const fetch = createH2Fetch({ tlsOptions: testTls });
     try {
-      await expect(fetch(`${redirectServer.origin}/redirect`, { redirect: 'error' })).rejects.toThrow(
-        /Redirect response/,
-      );
+      const response = await fetch(`${redirectServer.origin}/redirect`, { redirect: 'manual' });
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe('https://attacker.invalid/collect');
     } finally {
       await fetch.close();
       await redirectServer.close();

--- a/tests/lib/h2-transport/index.test.ts
+++ b/tests/lib/h2-transport/index.test.ts
@@ -151,6 +151,22 @@ describe('createH2Fetch', () => {
     await fetch.close();
   });
 
+  test('rejects redirect responses when redirect mode is error', async () => {
+    const redirectServer = await startTestServer((stream) => {
+      stream.respond({ ':status': 302, location: 'https://attacker.invalid/collect' });
+      stream.end();
+    });
+    const fetch = createH2Fetch({ tlsOptions: testTls });
+    try {
+      await expect(fetch(`${redirectServer.origin}/redirect`, { redirect: 'error' })).rejects.toThrow(
+        /Redirect response/,
+      );
+    } finally {
+      await fetch.close();
+      await redirectServer.close();
+    }
+  });
+
   test('throws on Node < 18', () => {
     const real = process.versions.node;
     Object.defineProperty(process.versions, 'node', { value: '16.20.0', configurable: true });

--- a/tests/lib/h2-transport/index.test.ts
+++ b/tests/lib/h2-transport/index.test.ts
@@ -35,6 +35,17 @@ describe('createH2Fetch', () => {
     const echoed = await r.json();
     expect(echoed['x-mixed-case']).toBe('yes');
     expect(echoed['accept']).toBe('application/json');
+    expect(echoed['host']).toBe(new URL(server.origin).host);
+    await fetch.close();
+  });
+
+  test('derives Host from the request URL instead of caller headers', async () => {
+    const fetch = createH2Fetch({ tlsOptions: testTls });
+    const r = (await fetch(`${server.origin}/headers`, {
+      method: 'GET',
+      headers: { host: 'attacker.invalid' },
+    })) as any;
+    expect((await r.json()).host).toBe(new URL(server.origin).host);
     await fetch.close();
   });
 

--- a/tests/lib/h2-transport/pool.test.ts
+++ b/tests/lib/h2-transport/pool.test.ts
@@ -1,5 +1,5 @@
 import { H2Pool } from '../../../src/lib/h2-transport/pool';
-import { H2GoawayError, SessionState } from '../../../src/lib/h2-transport/session';
+import { H2GoawayError, H2Session, SessionState } from '../../../src/lib/h2-transport/session';
 import { cleanupCerts, testTls } from './helpers/certs';
 import { defaultHandler, startTestServer, TestServer } from './helpers/testServer';
 
@@ -136,6 +136,31 @@ describe('H2Pool', () => {
       /closed/,
     );
     expect((pool as any)._queue).toHaveLength(0);
+  });
+
+  test('closes a session that finishes connecting after pool shutdown', async () => {
+    let finishConnect!: () => void;
+    const connect = jest.spyOn(H2Session.prototype, 'connect').mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishConnect = resolve;
+        }),
+    );
+    const close = jest.spyOn(H2Session.prototype, 'close').mockResolvedValue();
+    try {
+      const pool = new H2Pool(server.origin, { minConnections: 1 });
+      const request = (pool as any)._enqueueRequest('/late', 'GET', {}, null, undefined, false);
+
+      await Promise.resolve();
+      await pool.close();
+      finishConnect();
+      await expect(request).rejects.toThrow(/closed/);
+      expect(close).toHaveBeenCalledTimes(1);
+      expect((pool as any)._sessions).toHaveLength(0);
+    } finally {
+      connect.mockRestore();
+      close.mockRestore();
+    }
   });
 
   test('retries a safe stream that GOAWAY proves was not processed', async () => {

--- a/tests/lib/h2-transport/pool.test.ts
+++ b/tests/lib/h2-transport/pool.test.ts
@@ -139,21 +139,22 @@ describe('H2Pool', () => {
   });
 
   test('closes a session that finishes connecting after pool shutdown', async () => {
-    let finishConnect!: () => void;
+    let failConnect!: (error: Error) => void;
     const connect = jest.spyOn(H2Session.prototype, 'connect').mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
-          finishConnect = resolve;
+        new Promise<void>((_resolve, reject) => {
+          failConnect = reject;
         }),
     );
-    const close = jest.spyOn(H2Session.prototype, 'close').mockResolvedValue();
+    const close = jest.spyOn(H2Session.prototype, 'close').mockImplementation(async () => {
+      failConnect(new Error('closed while connecting'));
+    });
     try {
       const pool = new H2Pool(server.origin, { minConnections: 1 });
       const request = (pool as any)._enqueueRequest('/late', 'GET', {}, null, undefined, false);
 
       await Promise.resolve();
       await pool.close();
-      finishConnect();
       await expect(request).rejects.toThrow(/closed/);
       expect(close).toHaveBeenCalledTimes(1);
       expect((pool as any)._sessions).toHaveLength(0);

--- a/tests/lib/h2-transport/pool.test.ts
+++ b/tests/lib/h2-transport/pool.test.ts
@@ -1,4 +1,5 @@
 import { H2Pool } from '../../../src/lib/h2-transport/pool';
+import { H2GoawayError, SessionState } from '../../../src/lib/h2-transport/session';
 import { cleanupCerts, testTls } from './helpers/certs';
 import { defaultHandler, startTestServer, TestServer } from './helpers/testServer';
 
@@ -126,5 +127,34 @@ describe('H2Pool', () => {
   test('close() before initialize() is safe', async () => {
     const pool = new H2Pool(server.origin, { tlsOptions: testTls });
     await expect(pool.close()).resolves.toBeUndefined();
+  });
+
+  test('retries a safe stream that GOAWAY proves was not processed', async () => {
+    const pool = new H2Pool(server.origin);
+    const retry = jest
+      .spyOn(pool as any, '_enqueueRequest')
+      .mockResolvedValue({ status: 200, retried: true });
+    const session = {
+      state: SessionState.DRAINING,
+      request: jest.fn().mockRejectedValue(new H2GoawayError(0, 1, undefined, true)),
+    };
+
+    await expect((pool as any)._dispatchToSession(session, '/safe', 'GET', {}, null)).resolves.toMatchObject({
+      retried: true,
+    });
+    expect(retry).toHaveBeenCalledWith('/safe', 'GET', {}, null, undefined, false);
+  });
+
+  test('does not retry an accepted stream terminated by idle GOAWAY', async () => {
+    const pool = new H2Pool(server.origin);
+    const cause = new H2GoawayError(0, 1, Buffer.from('idle_timeout'), false);
+    const retry = jest.spyOn(pool as any, '_enqueueRequest');
+    const session = {
+      state: SessionState.DRAINING,
+      request: jest.fn().mockRejectedValue(cause),
+    };
+
+    await expect((pool as any)._dispatchToSession(session, '/idle', 'GET', {}, null)).rejects.toBe(cause);
+    expect(retry).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/h2-transport/pool.test.ts
+++ b/tests/lib/h2-transport/pool.test.ts
@@ -129,6 +129,15 @@ describe('H2Pool', () => {
     await expect(pool.close()).resolves.toBeUndefined();
   });
 
+  test('does not enqueue a retry after the pool is closed', async () => {
+    const pool = new H2Pool(server.origin, { minConnections: 1, tlsOptions: testTls });
+    await pool.close();
+    await expect((pool as any)._enqueueRequest('/late', 'GET', {}, null, undefined, false)).rejects.toThrow(
+      /closed/,
+    );
+    expect((pool as any)._queue).toHaveLength(0);
+  });
+
   test('retries a safe stream that GOAWAY proves was not processed', async () => {
     const pool = new H2Pool(server.origin);
     const retry = jest

--- a/tests/lib/h2-transport/session.test.ts
+++ b/tests/lib/h2-transport/session.test.ts
@@ -75,6 +75,27 @@ describe('H2Session', () => {
     await blackhole.close();
   });
 
+  test('close interrupts an in-progress connection within a bounded deadline', async () => {
+    const blackhole = await startBlackholeServer();
+    const s = new H2Session(`https://localhost:${blackhole.port}`, {
+      connectTimeout: 30_000,
+      tlsOptions: testTls,
+    });
+    const connecting = s.connect();
+    const connectionResult = connecting.catch((error) => error);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const deadline = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('session close did not settle within 1 second')), 1_000);
+      });
+      await expect(Promise.race([s.close(), deadline])).resolves.toBeUndefined();
+      await expect(connectionResult).resolves.toThrow(/closed while connecting/);
+    } finally {
+      if (timer) clearTimeout(timer);
+      await blackhole.close();
+    }
+  });
+
   test('GET returns JSON', async () => {
     const s = new H2Session(server.origin, { tlsOptions: testTls });
     await s.connect();

--- a/tests/smoketests/object-oriented/agent-coverage.test.ts
+++ b/tests/smoketests/object-oriented/agent-coverage.test.ts
@@ -1,0 +1,55 @@
+import { RunloopSDK } from '@runloop/api-client';
+import { Response, type RequestInfo } from 'node-fetch';
+
+(process.env['RUN_SMOKETESTS'] ? describe : describe.skip)('object-oriented agent coverage', () => {
+  test('covers public listing, deletion, and devbox counts without external I/O', async () => {
+    const fetch = jest.fn((request: RequestInfo) => {
+      const url = request.toString();
+      if (url.endsWith('/v1/agents/list_public?limit=1')) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              agents: [
+                {
+                  id: 'agt_public',
+                  create_time_ms: 1,
+                  is_public: true,
+                  name: 'public-agent',
+                },
+              ],
+              has_more: false,
+              total_count: 1,
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          ),
+        );
+      }
+      if (url.endsWith('/v1/agents/devbox_counts')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ counts: { 'public-agent': 2 }, total_count: 2 }), {
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      if (url.endsWith('/v1/agents/agt_public/delete')) {
+        return Promise.resolve(new Response(undefined, { status: 204 }));
+      }
+      return Promise.reject(new Error(`Unexpected request: ${url}`));
+    });
+    const sdk = new RunloopSDK({
+      bearerToken: 'test',
+      baseURL: 'https://example.invalid',
+      maxRetries: 0,
+      fetch: fetch as any,
+    });
+
+    const agents = await sdk.agent.listPublic({ limit: 1 });
+    expect(agents.map((agent) => agent.id)).toEqual(['agt_public']);
+    await expect(sdk.agent.delete(agents[0]!)).resolves.toBeUndefined();
+    await expect(sdk.agent.getDevboxCounts()).resolves.toEqual({
+      counts: { 'public-agent': 2 },
+      total_count: 2,
+    });
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/smoketests/object-oriented/eviction.test.ts
+++ b/tests/smoketests/object-oriented/eviction.test.ts
@@ -102,4 +102,24 @@ const tick = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms));
     await tick();
     expect(callback).not.toHaveBeenCalled();
   });
+
+  test('cancelOnEvict clears a pending reconnect timer', async () => {
+    jest.useFakeTimers();
+    try {
+      const watchEvictions = jest.fn(async () => streamOf([]));
+      const devbox = Devbox.fromId(fakeClient(watchEvictions), 'dbx_backoff');
+
+      devbox.onEvict(jest.fn());
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(watchEvictions).toHaveBeenCalledTimes(1);
+      expect(jest.getTimerCount()).toBe(1);
+
+      devbox.cancelOnEvict();
+      expect(jest.getTimerCount()).toBe(0);
+      await Promise.resolve();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/tests/smoketests/object-oriented/eviction.test.ts
+++ b/tests/smoketests/object-oriented/eviction.test.ts
@@ -122,4 +122,28 @@ const tick = (ms = 20) => new Promise((resolve) => setTimeout(resolve, ms));
       jest.useRealTimers();
     }
   });
+
+  test('cancel and re-register does not leave a stale reconnect timer', async () => {
+    jest.useFakeTimers();
+    try {
+      const firstStream = blockingStream();
+      const secondStream = blockingStream();
+      const watchEvictions = jest.fn().mockResolvedValueOnce(firstStream).mockResolvedValueOnce(secondStream);
+      const devbox = Devbox.fromId(fakeClient(watchEvictions), 'dbx_reregister');
+
+      devbox.onEvict(jest.fn());
+      await Promise.resolve();
+      devbox.cancelOnEvict();
+      devbox.onEvict(jest.fn());
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(watchEvictions).toHaveBeenCalledTimes(2);
+      expect(jest.getTimerCount()).toBe(0);
+      devbox.cancelOnEvict();
+      await Promise.resolve();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 });

--- a/tests/smoketests/object-oriented/tunnel-readiness.test.ts
+++ b/tests/smoketests/object-oriented/tunnel-readiness.test.ts
@@ -1,6 +1,7 @@
 import { Devbox } from '../../../src/sdk/devbox';
 import { InternalServerError } from '../../../src/error';
-import { Response } from 'node-fetch';
+import { Runloop } from '../../../src';
+import { Headers, Response, type RequestInfo, type RequestInit } from 'node-fetch';
 
 describe('object-oriented tunnel readiness', () => {
   test('net helper requests the optional health path through the established tunnel', async () => {
@@ -40,10 +41,67 @@ describe('object-oriented tunnel readiness', () => {
       expect.objectContaining({
         maxRetries: 0,
         signal,
+        redirect: 'error',
         headers: { authorization: 'Bearer tunnel-token' },
       }),
     );
     expect(asResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not send API or tunnel credentials to a cross-origin redirect', async () => {
+    const calls: Array<{ url: string; authorization: string | null; redirect: string | undefined }> = [];
+    const fetch = jest.fn(async (request: RequestInfo, init?: RequestInit): Promise<Response> => {
+      const url = request.toString();
+      const authorization = new Headers(init?.headers).get('authorization');
+      calls.push({ url, authorization, redirect: init?.redirect });
+
+      if (url === 'https://api.runloop.ai/v1/devboxes/dbx') {
+        return new Response(
+          JSON.stringify({
+            id: 'dbx',
+            tunnel: {
+              tunnel_key: 'tunnel-key',
+              auth_mode: 'authenticated',
+              auth_token: 'tunnel-token',
+            },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === 'https://8080-tunnel-key.tunnel.runloop.ai/health') {
+        if (init?.redirect === 'error') {
+          throw new TypeError('Redirect mode is set to error');
+        }
+        return fetch('https://attacker.invalid/collect', init);
+      }
+      return new Response('captured', { status: 200 });
+    });
+    const client = new Runloop({
+      bearerToken: 'api-bearer',
+      baseURL: 'https://api.runloop.ai',
+      maxRetries: 0,
+      fetch: fetch as any,
+    });
+    const devbox = Devbox.fromId(client, 'dbx');
+
+    await expect(
+      devbox.awaitTunnelReady(8080, { path: '/health', timeoutMs: 1_000 }),
+    ).rejects.toBeDefined();
+
+    expect(calls).toEqual([
+      {
+        url: 'https://api.runloop.ai/v1/devboxes/dbx',
+        authorization: 'Bearer api-bearer',
+        redirect: undefined,
+      },
+      {
+        url: 'https://8080-tunnel-key.tunnel.runloop.ai/health',
+        authorization: 'Bearer tunnel-token',
+        redirect: 'error',
+      },
+    ]);
+    expect(calls.some((call) => call.url === 'https://attacker.invalid/collect')).toBe(false);
+    expect(calls[1]?.authorization).not.toBe('Bearer api-bearer');
   });
 
   test('Devbox helper delegates to its network operations', async () => {

--- a/tests/smoketests/object-oriented/tunnel-readiness.test.ts
+++ b/tests/smoketests/object-oriented/tunnel-readiness.test.ts
@@ -1,4 +1,5 @@
 import { Devbox } from '../../../src/sdk/devbox';
+import { InternalServerError } from '../../../src/error';
 import { Response } from 'node-fetch';
 
 describe('object-oriented tunnel readiness', () => {
@@ -53,5 +54,32 @@ describe('object-oriented tunnel readiness', () => {
 
     await expect(devbox.awaitTunnelReady(3000, { path: '/ready' })).resolves.toBe(response);
     expect(ready).toHaveBeenCalledWith(3000, { path: '/ready' });
+  });
+
+  test('tunnel_unavailable is terminal in the object-oriented helper', async () => {
+    const unavailable = InternalServerError.generate(
+      503,
+      { error: 'tunnel_unavailable', retryable: true },
+      undefined,
+      { 'x-should-retry': 'true' },
+    );
+    const asResponse = jest.fn().mockRejectedValue(unavailable);
+    const client: any = {
+      baseURL: 'https://api.runloop.ai',
+      devboxes: {
+        retrieve: jest.fn().mockResolvedValue({
+          tunnel: { tunnel_key: 'tunnel-key', auth_mode: 'open', auth_token: null },
+        }),
+      },
+      get: jest.fn().mockReturnValue({ asResponse }),
+    };
+    const devbox = Devbox.fromId(client, 'dbx');
+
+    await expect(
+      devbox.awaitTunnelReady(8080, { path: '/health', timeoutMs: 1_000, retryIntervalMs: 0 }),
+    ).rejects.toBe(unavailable);
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(asResponse).toHaveBeenCalledTimes(1);
+    expect(unavailable.attempts).toBe(1);
   });
 });

--- a/tests/smoketests/object-oriented/tunnel-readiness.test.ts
+++ b/tests/smoketests/object-oriented/tunnel-readiness.test.ts
@@ -42,18 +42,28 @@ describe('object-oriented tunnel readiness', () => {
         maxRetries: 0,
         signal,
         redirect: 'error',
-        headers: { authorization: 'Bearer tunnel-token' },
+        headers: {
+          authorization: null,
+          'x-runloop-tunnel-authorization': 'Bearer tunnel-token',
+        },
       }),
     );
     expect(asResponse).toHaveBeenCalledTimes(1);
   });
 
   test('does not send API or tunnel credentials to a cross-origin redirect', async () => {
-    const calls: Array<{ url: string; authorization: string | null; redirect: string | undefined }> = [];
+    const calls: Array<{
+      url: string;
+      authorization: string | null;
+      tunnelAuthorization: string | null;
+      redirect: string | undefined;
+    }> = [];
     const fetch = jest.fn(async (request: RequestInfo, init?: RequestInit): Promise<Response> => {
       const url = request.toString();
-      const authorization = new Headers(init?.headers).get('authorization');
-      calls.push({ url, authorization, redirect: init?.redirect });
+      const headers = new Headers(init?.headers);
+      const authorization = headers.get('authorization');
+      const tunnelAuthorization = headers.get('x-runloop-tunnel-authorization');
+      calls.push({ url, authorization, tunnelAuthorization, redirect: init?.redirect });
 
       if (url === 'https://api.runloop.ai/v1/devboxes/dbx') {
         return new Response(
@@ -92,16 +102,20 @@ describe('object-oriented tunnel readiness', () => {
       {
         url: 'https://api.runloop.ai/v1/devboxes/dbx',
         authorization: 'Bearer api-bearer',
+        tunnelAuthorization: null,
         redirect: undefined,
       },
       {
         url: 'https://8080-tunnel-key.tunnel.runloop.ai/health',
-        authorization: 'Bearer tunnel-token',
+        authorization: null,
+        tunnelAuthorization: 'Bearer tunnel-token',
         redirect: 'error',
       },
     ]);
     expect(calls.some((call) => call.url === 'https://attacker.invalid/collect')).toBe(false);
-    expect(calls[1]?.authorization).not.toBe('Bearer api-bearer');
+    expect(calls[1]).not.toEqual(
+      expect.objectContaining({ authorization: 'Bearer api-bearer', tunnelAuthorization: null }),
+    );
   });
 
   test('Devbox helper delegates to its network operations', async () => {

--- a/tests/smoketests/object-oriented/tunnel-readiness.test.ts
+++ b/tests/smoketests/object-oriented/tunnel-readiness.test.ts
@@ -1,5 +1,5 @@
 import { Devbox } from '../../../src/sdk/devbox';
-import { InternalServerError } from '../../../src/error';
+import { APIError, InternalServerError } from '../../../src/error';
 import { Runloop } from '../../../src';
 import { Headers, Response, type RequestInfo, type RequestInit } from 'node-fetch';
 
@@ -41,7 +41,7 @@ describe('object-oriented tunnel readiness', () => {
       expect.objectContaining({
         maxRetries: 0,
         signal,
-        redirect: 'error',
+        redirect: 'manual',
         headers: {
           authorization: null,
           'x-runloop-tunnel-authorization': 'Bearer tunnel-token',
@@ -79,8 +79,11 @@ describe('object-oriented tunnel readiness', () => {
         );
       }
       if (url === 'https://8080-tunnel-key.tunnel.runloop.ai/health') {
-        if (init?.redirect === 'error') {
-          throw new TypeError('Redirect mode is set to error');
+        if (init?.redirect === 'manual') {
+          return new Response(undefined, {
+            status: 302,
+            headers: { location: 'https://attacker.invalid/collect' },
+          });
         }
         return fetch('https://attacker.invalid/collect', init);
       }
@@ -94,9 +97,12 @@ describe('object-oriented tunnel readiness', () => {
     });
     const devbox = Devbox.fromId(client, 'dbx');
 
-    await expect(
-      devbox.awaitTunnelReady(8080, { path: '/health', timeoutMs: 1_000 }),
-    ).rejects.toBeDefined();
+    const error = await devbox
+      .awaitTunnelReady(8080, { path: '/health', timeoutMs: 1_000 })
+      .catch((value) => value);
+
+    expect(error).toBeInstanceOf(APIError);
+    expect(error).toMatchObject({ status: 302, attempts: 1 });
 
     expect(calls).toEqual([
       {
@@ -109,9 +115,10 @@ describe('object-oriented tunnel readiness', () => {
         url: 'https://8080-tunnel-key.tunnel.runloop.ai/health',
         authorization: null,
         tunnelAuthorization: 'Bearer tunnel-token',
-        redirect: 'error',
+        redirect: 'manual',
       },
     ]);
+    expect(calls.filter((call) => call.url.includes('.tunnel.runloop.ai/health'))).toHaveLength(1);
     expect(calls.some((call) => call.url === 'https://attacker.invalid/collect')).toBe(false);
     expect(calls[1]).not.toEqual(
       expect.objectContaining({ authorization: 'Bearer api-bearer', tunnelAuthorization: null }),

--- a/tests/smoketests/object-oriented/tunnel-readiness.test.ts
+++ b/tests/smoketests/object-oriented/tunnel-readiness.test.ts
@@ -1,0 +1,57 @@
+import { Devbox } from '../../../src/sdk/devbox';
+import { Response } from 'node-fetch';
+
+describe('object-oriented tunnel readiness', () => {
+  test('net helper requests the optional health path through the established tunnel', async () => {
+    const response = new Response('ok');
+    const asResponse = jest.fn().mockResolvedValue(response);
+    const signal = new AbortController().signal;
+    const client: any = {
+      baseURL: 'https://api.runloop.ai',
+      devboxes: {
+        retrieve: jest.fn().mockResolvedValue({
+          tunnel: {
+            tunnel_key: 'tunnel-key',
+            auth_mode: 'authenticated',
+            auth_token: 'tunnel-token',
+          },
+        }),
+      },
+      get: jest.fn().mockReturnValue({ asResponse }),
+    };
+    const devbox = Devbox.fromId(client, 'dbx');
+
+    await expect(
+      devbox.net.awaitTunnelReady(8080, {
+        path: '/healthz?ready=1',
+        timeoutMs: 1_000,
+        signal,
+      }),
+    ).resolves.toBe(response);
+
+    expect(client.devboxes.retrieve).toHaveBeenCalledWith('dbx', {
+      maxRetries: 0,
+      timeout: 1_000,
+      signal,
+    });
+    expect(client.get).toHaveBeenCalledWith(
+      'https://8080-tunnel-key.tunnel.runloop.ai/healthz?ready=1',
+      expect.objectContaining({
+        maxRetries: 0,
+        signal,
+        headers: { authorization: 'Bearer tunnel-token' },
+      }),
+    );
+    expect(asResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('Devbox helper delegates to its network operations', async () => {
+    const client: any = { baseURL: 'https://api.runloop.ai' };
+    const devbox = Devbox.fromId(client, 'dbx');
+    const response = new Response('ok');
+    const ready = jest.spyOn(devbox.net, 'awaitTunnelReady').mockResolvedValue(response as any);
+
+    await expect(devbox.awaitTunnelReady(3000, { path: '/ready' })).resolves.toBe(response);
+    expect(ready).toHaveBeenCalledWith(3000, { path: '/ready' });
+  });
+});

--- a/tests/smoketests/utils.ts
+++ b/tests/smoketests/utils.ts
@@ -26,9 +26,12 @@ function makeTestAgent(baseURL: string | undefined, http2: boolean | object): Ag
 // Object coverage runs files in parallel Jest workers. Give each worker owned
 // HTTP/1.1 agents so teardown does not wait for the SDK's process-wide 30s
 // keep-alive pool (which previously forced Jest to kill a worker).
-afterAll(() => {
+afterAll(async () => {
   for (const agent of testAgents) agent.destroy();
   testAgents.clear();
+  // agent.destroy() closes sockets asynchronously. Give their close callbacks
+  // one event-loop turn to run before Jest decides whether the worker leaked.
+  await new Promise<void>((resolve) => setImmediate(resolve));
 });
 
 export function makeClient(overrides: Partial<ConstructorParameters<typeof Runloop>[0]> = {}) {

--- a/tests/smoketests/utils.ts
+++ b/tests/smoketests/utils.ts
@@ -2,6 +2,8 @@ import { Runloop, RunloopSDK } from '@runloop/api-client';
 import { NetworkPolicy, GatewayConfig, McpConfig } from '@runloop/api-client/sdk';
 import KeepAliveAgent from 'agentkeepalive';
 import type { Agent } from 'node:http';
+import type { Socket } from 'node:net';
+import nodeFetch from 'node-fetch';
 
 /**
  * Run the smoke tests over HTTP/2 (the undici adapter) instead of the default
@@ -11,6 +13,13 @@ import type { Agent } from 'node:http';
 export const useHttp2 = ['1', 'true'].includes((process.env['SMOKE_HTTP2'] ?? '').toLowerCase());
 
 const testAgents = new Set<Agent>();
+const originalGlobalFetch = globalThis.fetch;
+
+// Storage-object helpers intentionally use the platform fetch for presigned
+// uploads. Node's built-in fetch keeps its process-wide Undici dispatcher alive
+// beyond a Jest suite, so use the SDK's non-pooling node-fetch implementation in
+// smoke workers and restore the platform function during teardown.
+globalThis.fetch = nodeFetch as unknown as typeof globalThis.fetch;
 
 function makeTestAgent(baseURL: string | undefined, http2: boolean | object): Agent | undefined {
   if (http2) return undefined;
@@ -27,11 +36,24 @@ function makeTestAgent(baseURL: string | undefined, http2: boolean | object): Ag
 // HTTP/1.1 agents so teardown does not wait for the SDK's process-wide 30s
 // keep-alive pool (which previously forced Jest to kill a worker).
 afterAll(async () => {
+  const sockets = new Set<Socket>();
+  for (const agent of testAgents) {
+    for (const group of [...Object.values(agent.sockets), ...Object.values(agent.freeSockets)]) {
+      for (const socket of group ?? []) sockets.add(socket);
+    }
+  }
+  const closed = [...sockets]
+    .filter((socket) => !socket.destroyed)
+    .map(
+      (socket) =>
+        new Promise<void>((resolve) => {
+          socket.once('close', resolve);
+        }),
+    );
   for (const agent of testAgents) agent.destroy();
   testAgents.clear();
-  // agent.destroy() closes sockets asynchronously. Give their close callbacks
-  // one event-loop turn to run before Jest decides whether the worker leaked.
-  await new Promise<void>((resolve) => setImmediate(resolve));
+  await Promise.all(closed);
+  globalThis.fetch = originalGlobalFetch;
 });
 
 export function makeClient(overrides: Partial<ConstructorParameters<typeof Runloop>[0]> = {}) {

--- a/tests/smoketests/utils.ts
+++ b/tests/smoketests/utils.ts
@@ -1,5 +1,7 @@
 import { Runloop, RunloopSDK } from '@runloop/api-client';
 import { NetworkPolicy, GatewayConfig, McpConfig } from '@runloop/api-client/sdk';
+import KeepAliveAgent from 'agentkeepalive';
+import type { Agent } from 'node:http';
 
 /**
  * Run the smoke tests over HTTP/2 (the undici adapter) instead of the default
@@ -8,17 +10,40 @@ import { NetworkPolicy, GatewayConfig, McpConfig } from '@runloop/api-client/sdk
  */
 export const useHttp2 = ['1', 'true'].includes((process.env['SMOKE_HTTP2'] ?? '').toLowerCase());
 
+const testAgents = new Set<Agent>();
+
+function makeTestAgent(baseURL: string | undefined, http2: boolean | object): Agent | undefined {
+  if (http2) return undefined;
+  const options = { keepAlive: true, freeSocketTimeout: 4_000 };
+  const agent =
+    (baseURL ?? 'https://api.runloop.ai').startsWith('https:') ?
+      new KeepAliveAgent.HttpsAgent(options)
+    : new KeepAliveAgent(options);
+  testAgents.add(agent);
+  return agent;
+}
+
+// Object coverage runs files in parallel Jest workers. Give each worker owned
+// HTTP/1.1 agents so teardown does not wait for the SDK's process-wide 30s
+// keep-alive pool (which previously forced Jest to kill a worker).
+afterAll(() => {
+  for (const agent of testAgents) agent.destroy();
+  testAgents.clear();
+});
+
 export function makeClient(overrides: Partial<ConstructorParameters<typeof Runloop>[0]> = {}) {
   const baseURL = process.env['RUNLOOP_BASE_URL'];
   const bearerToken = process.env['RUNLOOP_API_KEY'];
+  const http2 = overrides.http2 ?? useHttp2;
 
   return new Runloop({
     baseURL,
     bearerToken,
     timeout: 120_000,
     maxRetries: 3,
-    http2: useHttp2,
+    http2,
     ...overrides,
+    httpAgent: overrides.httpAgent ?? makeTestAgent(baseURL, http2),
   });
 }
 
@@ -29,6 +54,7 @@ export function makeClientSDK() {
     timeout: 120_000,
     maxRetries: 3,
     http2: useHttp2,
+    httpAgent: makeTestAgent(process.env['RUNLOOP_BASE_URL'], useHttp2),
   });
 }
 

--- a/tests/smoketests/utils.ts
+++ b/tests/smoketests/utils.ts
@@ -54,18 +54,6 @@ afterAll(async () => {
   testAgents.clear();
   await Promise.all(closed);
   globalThis.fetch = originalGlobalFetch;
-  if (process.env['CI']) {
-    const handles = (process as any)
-      ._getActiveHandles()
-      .map((handle: object) => handle.constructor?.name ?? 'unknown');
-    console.warn(
-      `[smoke teardown] ${expect.getState().testPath}: handles=${handles.join(',')} resources=${(
-        process as any
-      )
-        .getActiveResourcesInfo()
-        .join(',')}`,
-    );
-  }
 });
 
 export function makeClient(overrides: Partial<ConstructorParameters<typeof Runloop>[0]> = {}) {

--- a/tests/smoketests/utils.ts
+++ b/tests/smoketests/utils.ts
@@ -54,6 +54,18 @@ afterAll(async () => {
   testAgents.clear();
   await Promise.all(closed);
   globalThis.fetch = originalGlobalFetch;
+  if (process.env['CI']) {
+    const handles = (process as any)
+      ._getActiveHandles()
+      .map((handle: object) => handle.constructor?.name ?? 'unknown');
+    console.warn(
+      `[smoke teardown] ${expect.getState().testPath}: handles=${handles.join(',')} resources=${(
+        process as any
+      )
+        .getActiveResourcesInfo()
+        .join(',')}`,
+    );
+  }
 });
 
 export function makeClient(overrides: Partial<ConstructorParameters<typeof Runloop>[0]> = {}) {


### PR DESCRIPTION
## **User description**
## Summary
- expose stable normalized Runloop error details across server, fetch, Undici, and HTTP/2 failures
- make retry behavior operation-safe while retaining attempts, retry headers, request IDs, and final causes
- preserve typed GOAWAY debug metadata before headers and during interrupted response bodies
- add bounded object-oriented tunnel readiness polling with an optional health path, terminal `tunnel_unavailable`, and redirect-blocked credential handling
- make smoke-test upload/HTTP agents and eviction reconnect timers tear down deterministically
- stop the coverage workflow from overriding its 50% worker limit with an 800% oversubscription
- restore 100% object function coverage with hermetic coverage for the new tunnel helpers and existing uncovered agent methods

## Validated full review

**Decision:** `approve` at pinned base `8ee97f7f654b0d812b39b09684126046c16cc580` and final head `c4377cb7c0bb3afa4edc732d177d4c28b640610a`.

**Observed scope / partition:** all 19 changed files are in scope: normalized error/retry behavior, HTTP/2 failure handling, tunnel readiness and credential-safe redirects, teardown/coverage workflow changes, and focused regressions. There are no drive-by or merge-ghost files.

- **Deep pass:** completed read-only against the pinned final `base...head` diff, tracing normalization, retry safety, HTTP/2 session/pool lifetime, body consumption, redirect policy, tunnel authentication, readiness polling, eviction backoff, smoke transport cleanup, and callers/tests. It returned no remaining introduced actionable findings.
- **Readiness pass:** independently completed against the same pinned diff and observable contract. It verified terminal `tunnel_unavailable`, optional health paths, tunnel-specific authentication with API-bearer removal, manual, terminal redirects across both fetch transports, preserved causes for parsed and binary bodies, bounded safe retries, 100% object function coverage, and deterministic worker teardown. It returned no remaining introduced actionable findings.
- Both passes were complete and SHA-aligned; all citations and seven automated review threads were re-read. Six important findings were accepted and fixed: HTTP/2 manual-redirect parity (`src/lib/h2-transport/index.ts`), stalled error-body retry policy (`src/core.ts`), transport-code classification (`src/lib/error-normalization.ts`), binary cause preservation (`src/lib/h2-transport/index.ts`), pool-close races (`src/lib/h2-transport/pool.ts`), and the documented tunnel credential header (`src/sdk/devbox.ts`).
- One GOAWAY suggestion was rejected after validation: GOAWAY drains a session but does not prove an accepted no-Content-Length stream was truncated. Actual stream error/close paths already surface the retained GOAWAY cause, while clean END_STREAM remains successful. All review threads are resolved with rationale.
- Earlier accepted findings also remain fixed: interrupted-body GOAWAY causes are preserved and stale eviction reconnect timers are prevented.
- Live HTTP/2 compatibility is covered by explicitly deriving the `Host` header from the request URL (`src/lib/h2-transport/index.ts`); transport regressions verify it is present and cannot be overridden by caller input.
- HTTP/2 pool shutdown now tracks and aborts sessions that are still connecting, with a one-second bounded blackhole regression; the exact idle-timeout `--detectOpenHandles` command exits cleanly.
- The worker warning was diagnosed as Jest worker oversubscription after deterministic transport teardown. The workflow now uses its configured 50% worker cap instead of `--maxWorkers=800%`; three subsequent coverage runs completed without the forced-worker/open-handle warning.

## Verification
- `RUN_SMOKETESTS=1 yarn jest --config jest.config.objects.js tests/smoketests/object-oriented/tunnel-readiness.test.ts --runInBand --detectOpenHandles --coverage=false` — 4 passed, including tunnel-header isolation and terminal 302 handling with no cross-origin follow
- `yarn test tests/error-details.test.ts tests/lib/h2-transport/idle-timeout.test.ts tests/lib/h2-transport/index.test.ts tests/lib/h2-transport/pool.test.ts --runInBand --detectOpenHandles` — 4 suites / 49 tests passed, no open handles
- `yarn test --runInBand` — 65 suites passed, 904 tests passed, 6 skipped
- `yarn lint`
- `yarn build`
- [SDK Smoke Tests & Coverage Check](https://github.com/runloopai/api-client-ts/actions/runs/31979595540) — 100% function coverage, 18 suites / 255 tests passed, 7 skipped, and no forced-worker/open-handle warning
- GitHub `build`, `build-package-test`, `lint`, `test`, and `smoke-and-coverage` checks all pass at the pinned final head

## Deferred / out of scope
- None.


___

## **CodeAnt-AI Description**
Normalize request failures and add safe tunnel readiness handling

### What Changed
- API errors now expose consistent codes, phases, retry guidance, request IDs, retry delays, attempt counts, and original causes across fetch, HTTP/2, timeout, and server failures.
- Retries are limited to safe operations, honor server guidance, preserve idempotency, and stop for ambiguous execution, tunnel, upload, and backend failures.
- HTTP/2 GOAWAY failures retain the peer’s metadata and interrupted response-body cause, while only unprocessed safe requests are retried.
- Added bounded tunnel readiness checks with optional health paths, retry delays, cancellation, and redirect blocking so credentials cannot be sent to another host.
- Eviction monitoring now stops reconnect timers immediately when monitoring is canceled or restarted.
- Added coverage for normalized errors, HTTP/2 failures, tunnel readiness, eviction teardown, agent behavior, and deterministic smoke-test cleanup.

### Impact
`✅ Clearer transport and tunnel failure details`
`✅ Fewer unsafe duplicate requests`
`✅ Safer tunnel health checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>





