### PR TITLE
docs(readme): lead with what Runloop is and add package keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
-# Runloop Node API Library
+# Runloop TypeScript SDK
 
 [![NPM version](https://img.shields.io/npm/v/@runloop/api-client.svg)](https://npmjs.org/package/@runloop/api-client) ![npm bundle size](https://img.shields.io/bundlephobia/minzip/@runloop/api-client)
 
-This library provides convenient access to the Runloop SDK & REST API from server-side TypeScript or JavaScript.
+Official TypeScript SDK for [Runloop](https://docs.runloop.ai) — secure microVM sandboxes (**devboxes**) where AI agents run code, edit files, and expose ports.
 
-The **RunloopSDK** is the recommended, modern way to interact with the Runloop API. It provides high-level object-oriented interfaces for common operations while maintaining full access to the underlying REST API through the `.api` property.
+Why teams pick Runloop:
 
-## MCP Server
-
-Use the Runloop MCP Server to enable AI assistants to interact with this API, allowing them to explore endpoints, make test requests, and use documentation to help integrate this SDK into your application.
-
-[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=%40runloop%2Fapi-client-mcp&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBydW5sb29wL2FwaS1jbGllbnQtbWNwIl0sImVudiI6eyJSVU5MT09QX0FQSV9LRVkiOiJNeSBCZWFyZXIgVG9rZW4ifX0)
-[![Install in VS Code](https://img.shields.io/badge/_-Add_to_VS_Code-blue?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA0MCA0MCI+PHBhdGggZmlsbD0iI0VFRSIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMzAuMjM1IDM5Ljg4NGEyLjQ5MSAyLjQ5MSAwIDAgMS0xLjc4MS0uNzNMMTIuNyAyNC43OGwtMy40NiAyLjYyNC0zLjQwNiAyLjU4MmExLjY2NSAxLjY2NSAwIDAgMS0xLjA4Mi4zMzggMS42NjQgMS42NjQgMCAwIDEtMS4wNDYtLjQzMWwtMi4yLTJhMS42NjYgMS42NjYgMCAwIDEgMC0yLjQ2M0w3LjQ1OCAyMCA0LjY3IDE3LjQ1MyAxLjUwNyAxNC41N2ExLjY2NSAxLjY2NSAwIDAgMSAwLTIuNDYzbDIuMi0yYTEuNjY1IDEuNjY1IDAgMCAxIDIuMTMtLjA5N2w2Ljg2MyA1LjIwOUwyOC40NTIuODQ0YTIuNDg4IDIuNDg4IDAgMCAxIDEuODQxLS43MjljLjM1MS4wMDkuNjk5LjA5MSAxLjAxOS4yNDVsOC4yMzYgMy45NjFhMi41IDIuNSAwIDAgMSAxLjQxNSAyLjI1M3YuMDk5LS4wNDVWMzMuMzd2LS4wNDUuMDk1YTIuNTAxIDIuNTAxIDAgMCAxLTEuNDE2IDIuMjU3bC04LjIzNSAzLjk2MWEyLjQ5MiAyLjQ5MiAwIDAgMS0xLjA3Ny4yNDZabS43MTYtMjguOTQ3LTExLjk0OCA5LjA2MiAxMS45NTIgOS4wNjUtLjAwNC0xOC4xMjdaIi8+PC9zdmc+)](https://vscode.stainless.com/mcp/%7B%22name%22%3A%22%40runloop%2Fapi-client-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40runloop%2Fapi-client-mcp%22%5D%2C%22env%22%3A%7B%22RUNLOOP_API_KEY%22%3A%22My%20Bearer%20Token%22%7D%7D)
-
-> Note: You may need to set environment variables in your MCP client.
+- **Sandboxes that live as long as your agent does.** Devboxes run for hours or days, and `suspend()` / `resume()` keeps the whole machine state between sessions.
+- **A real machine, not just a code runner.** Full filesystem, shell, background processes, and public URLs for ports.
+- **Fast repeat starts.** Blueprints and disk snapshots boot pre-built environments instead of reinstalling dependencies.
+- **Built for production.** SOC 2 compliant, with bring-your-own-cloud deployment on AWS, GCP, and Azure.
+- **Evaluation built in.** Scenarios, scorers, and benchmarks let you measure agent performance on the same platform you run it on.
 
 ## Installation
 
@@ -23,7 +20,7 @@ npm install @runloop/api-client
 
 ## Quickstart
 
-Here's a complete example that demonstrates the core SDK functionality:
+`RunloopSDK` is the recommended way to use the API. It gives you high-level objects for common operations, and the full REST API stays available on `.api`.
 
 ```typescript
 import { RunloopSDK } from '@runloop/api-client';
@@ -57,6 +54,15 @@ console.log('Devbox logs:', logs.logs);
 
 await devbox.shutdown();
 ```
+
+## MCP Server
+
+Use the Runloop MCP Server to enable AI assistants to interact with this API, allowing them to explore endpoints, make test requests, and use documentation to help integrate this SDK into your application.
+
+[![Add to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=%40runloop%2Fapi-client-mcp&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBydW5sb29wL2FwaS1jbGllbnQtbWNwIl0sImVudiI6eyJSVU5MT09QX0FQSV9LRVkiOiJNeSBCZWFyZXIgVG9rZW4ifX0)
+[![Install in VS Code](https://img.shields.io/badge/_-Add_to_VS_Code-blue?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCA0MCA0MCI+PHBhdGggZmlsbD0iI0VFRSIgZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNMzAuMjM1IDM5Ljg4NGEyLjQ5MSAyLjQ5MSAwIDAgMS0xLjc4MS0uNzNMMTIuNyAyNC43OGwtMy40NiAyLjYyNC0zLjQwNiAyLjU4MmExLjY2NSAxLjY2NSAwIDAgMS0xLjA4Mi4zMzggMS42NjQgMS42NjQgMCAwIDEtMS4wNDYtLjQzMWwtMi4yLTJhMS42NjYgMS42NjYgMCAwIDEgMC0yLjQ2M0w3LjQ1OCAyMCA0LjY3IDE3LjQ1MyAxLjUwNyAxNC41N2ExLjY2NSAxLjY2NSAwIDAgMSAwLTIuNDYzbDIuMi0yYTEuNjY1IDEuNjY1IDAgMCAxIDIuMTMtLjA5N2w2Ljg2MyA1LjIwOUwyOC40NTIuODQ0YTIuNDg4IDIuNDg4IDAgMCAxIDEuODQxLS43MjljLjM1MS4wMDkuNjk5LjA5MSAxLjAxOS4yNDVsOC4yMzYgMy45NjFhMi41IDIuNSAwIDAgMSAxLjQxNSAyLjI1M3YuMDk5LS4wNDVWMzMuMzd2LS4wNDUuMDk1YTIuNTAxIDIuNTAxIDAgMCAxLTEuNDE2IDIuMjU3bC04LjIzNSAzLjk2MWEyLjQ5MiAyLjQ5MiAwIDAgMS0xLjA3Ny4yNDZabS43MTYtMjguOTQ3LTExLjk0OCA5LjA2MiAxMS45NTIgOS4wNjUtLjAwNC0xOC4xMjdaIi8+PC9zdmc+)](https://vscode.stainless.com/mcp/%7B%22name%22%3A%22%40runloop%2Fapi-client-mcp%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40runloop%2Fapi-client-mcp%22%5D%2C%22env%22%3A%7B%22RUNLOOP_API_KEY%22%3A%22My%20Bearer%20Token%22%7D%7D)
+
+> Note: You may need to set environment variables in your MCP client.
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,22 @@
 {
   "name": "@runloop/api-client",
   "version": "1.31.0",
-  "description": "The official TypeScript library for the Runloop API",
+  "description": "Official TypeScript SDK for Runloop — secure microVM sandboxes (devboxes) where AI agents run code, edit files, and expose ports.",
+  "keywords": [
+    "runloop",
+    "sandbox",
+    "devbox",
+    "microvm",
+    "code-execution",
+    "code-interpreter",
+    "ai-agents",
+    "agent-runtime",
+    "agent-infrastructure",
+    "llm",
+    "typescript"
+  ],
+  "homepage": "https://docs.runloop.ai",
+  "bugs": "https://github.com/runloopai/api-client-ts/issues",
   "author": "Runloop <support@runloop.ai>",
   "types": "dist/sdk.d.ts",
   "main": "dist/sdk.js",


### PR DESCRIPTION
## **User description**
## Why

Coding agents pick a sandbox provider by searching, not from priors, so the metadata in this repo is part of the retrieval path. Today those signals are empty or generic:

- `package.json` has no `keywords` and no `homepage`, and the description ("The official TypeScript library for the Runloop API") never says *sandbox*, *AI agent*, or *code execution*.
- The README's first screen is a wall of base64-encoded MCP install badges, before it says what the package does.

## What changed

**`package.json`**
- Description leads with the category: "Official TypeScript SDK for Runloop — secure microVM sandboxes (devboxes) where AI agents run code, edit files, and expose ports."
- Added `keywords`: runloop, sandbox, devbox, microvm, code-execution, code-interpreter, ai-agents, agent-runtime, agent-infrastructure, llm, typescript.
- Added `homepage` pointing at docs.runloop.ai (was unset, so typedoc GitHub Pages was the effective landing spot) and a `bugs` URL.

**`README.md`**
- Retitled "Runloop TypeScript SDK"; opens with a one-line category statement and five plain benefit bullets (long-lived devboxes with `suspend()`/`resume()`, full machine with filesystem/shell/background processes/public port URLs, blueprints and snapshots for fast repeat starts, SOC 2 and BYOC on AWS/GCP/Azure, built-in scenarios/scorers/benchmarks).
- Moved the MCP badge section below the quickstart, so the first screen reads: what it is → `npm install` → working example.
- The `RunloopSDK`-vs-`.api` note moved into Quickstart.

No source or behavior changes. `prettier --check` passes on both files.

## Follow-ups (not in this PR)

- Both files are Stainless-generated surfaces, so these values need mirroring into the Stainless config or the next generation reverts them.
- GitHub repo description and topics are still empty — those are repo settings, not files.
- The same changes apply to `api-client-python`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Clarify the SDK’s sandbox offering and improve package discoverability

### What Changed
- The README now leads with Runloop’s secure microVM sandboxes for AI agents and summarizes their key capabilities, including persistent environments, full machine access, snapshots, cloud deployment, and evaluation tools.
- Installation and quickstart guidance appears before the MCP Server setup, helping new users understand and try the SDK sooner.
- Package metadata now identifies the SDK as a sandbox and agent platform, adds relevant search keywords, links to the documentation homepage, and provides the issue tracker.

### Impact
`✅ Clearer SDK purpose for AI agent developers`
`✅ Faster path from package discovery to first quickstart`
`✅ Easier npm search and documentation access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
